### PR TITLE
Add four spaces markdown for raw code blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -69,6 +69,10 @@
     'name': 'comment.hr.gfm'
   }
   {
+    'match': '^\\s{4}.+$'
+    'name': 'markup.code.raw.gfm'
+  }
+  {
     'begin': '^`{3,}\\s*coffee-?(script)?\\s*$'
     'beginCaptures':
       '0': 'name': 'support.gfm'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -98,6 +98,11 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("http://localhost:8080")
     expect(tokens[0]).toEqual value: "http://localhost:8080", scopes: ["source.gfm"]
 
+
+  it "tokenizes a four spaces code block", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("    bundle exec rake")
+    expect(tokens[0]).toEqual value: "    bundle exec rake", scopes: ["source.gfm", "markup.code.raw.gfm"]
+
   it "tokenizes a ``` code block```", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
     expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]


### PR DESCRIPTION
Add `gfm.code` to four spaces code blocks.

Also specify `raw` class so we can apply specific styling like this :

![capture decran 2014-03-01 a 01 28 38](https://f.cloud.github.com/assets/143380/2300821/fa4fb9f2-a10a-11e3-8e26-f7f6c4907d91.png)
