### PR TITLE
Add heading level class

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -31,9 +31,49 @@
       '0': 'name': 'markup.italic.gfm'
   }
   {
-    'begin': '^#{1,6}\\s+'
+    'begin': '^#{1}\\s+'
     'end': '$'
-    'name': 'markup.heading.gfm'
+    'name': 'markup.heading.heading-1.gfm'
+    'patterns': [
+      'include': '$self'
+    ]
+  }
+  {
+    'begin': '^#{2}\\s+'
+    'end': '$'
+    'name': 'markup.heading.heading-2.gfm'
+    'patterns': [
+      'include': '$self'
+    ]
+  }
+  {
+    'begin': '^#{3}\\s+'
+    'end': '$'
+    'name': 'markup.heading.heading-3.gfm'
+    'patterns': [
+      'include': '$self'
+    ]
+  }
+  {
+    'begin': '^#{4}\\s+'
+    'end': '$'
+    'name': 'markup.heading.heading-4.gfm'
+    'patterns': [
+      'include': '$self'
+    ]
+  }
+  {
+    'begin': '^#{5}\\s+'
+    'end': '$'
+    'name': 'markup.heading.heading-5.gfm'
+    'patterns': [
+      'include': '$self'
+    ]
+  }
+  {
+    'begin': '^#{6}\\s+'
+    'end': '$'
+    'name': 'markup.heading.heading-6.gfm'
     'patterns': [
       'include': '$self'
     ]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -70,20 +70,36 @@ describe "GitHub Flavored Markdown grammar", ->
 
   it "tokenizes headings", ->
     {tokens} = grammar.tokenizeLine("# Heading 1")
-    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.gfm"]
+    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+
+    {tokens} = grammar.tokenizeLine("## Heading 2")
+    expect(tokens[0]).toEqual value: "## ", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
+    expect(tokens[1]).toEqual value: "Heading 2", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
 
     {tokens} = grammar.tokenizeLine("### Heading 3")
-    expect(tokens[0]).toEqual value: "### ", scopes: ["source.gfm", "markup.heading.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 3", scopes: ["source.gfm", "markup.heading.gfm"]
+    expect(tokens[0]).toEqual value: "### ", scopes: ["source.gfm", "markup.heading.heading-3.gfm"]
+    expect(tokens[1]).toEqual value: "Heading 3", scopes: ["source.gfm", "markup.heading.heading-3.gfm"]
+
+    {tokens} = grammar.tokenizeLine("#### Heading 4")
+    expect(tokens[0]).toEqual value: "#### ", scopes: ["source.gfm", "markup.heading.heading-4.gfm"]
+    expect(tokens[1]).toEqual value: "Heading 4", scopes: ["source.gfm", "markup.heading.heading-4.gfm"]
+
+    {tokens} = grammar.tokenizeLine("##### Heading 5")
+    expect(tokens[0]).toEqual value: "##### ", scopes: ["source.gfm", "markup.heading.heading-5.gfm"]
+    expect(tokens[1]).toEqual value: "Heading 5", scopes: ["source.gfm", "markup.heading.heading-5.gfm"]
+
+    {tokens} = grammar.tokenizeLine("###### Heading 6")
+    expect(tokens[0]).toEqual value: "###### ", scopes: ["source.gfm", "markup.heading.heading-6.gfm"]
+    expect(tokens[1]).toEqual value: "Heading 6", scopes: ["source.gfm", "markup.heading.heading-6.gfm"]
 
   it "tokenzies matches inside of headers", ->
     {tokens} = grammar.tokenizeLine("# Heading :one:")
-    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.gfm"]
-    expect(tokens[1]).toEqual value: "Heading ", scopes: ["source.gfm", "markup.heading.gfm"]
-    expect(tokens[2]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.gfm", "string.emoji.gfm", "string.emoji.start.gfm"]
-    expect(tokens[3]).toEqual value: "one", scopes: ["source.gfm", "markup.heading.gfm", "string.emoji.gfm", "string.emoji.word.gfm"]
-    expect(tokens[4]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.gfm", "string.emoji.gfm", "string.emoji.end.gfm"]
+    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[1]).toEqual value: "Heading ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[2]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.start.gfm"]
+    expect(tokens[3]).toEqual value: "one", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.word.gfm"]
+    expect(tokens[4]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.end.gfm"]
 
   it "tokenizies an :emoji:", ->
     {tokens} = grammar.tokenizeLine("this is :no_good:")


### PR DESCRIPTION
For easier styling :

![capture decran 2014-03-01 a 01 47 01](https://f.cloud.github.com/assets/143380/2300846/a8142bc0-a10d-11e3-8464-4b2b2147ced2.png)

I did not used shorter `.h1`, `.h2` classes as is seems there is built-in styles in the atom browser for theses classes and would note produce a desired effect I think (36px on h1) :

![capture decran 2014-03-01 a 01 52 00](https://f.cloud.github.com/assets/143380/2300853/05217db8-a10e-11e3-9f66-94010fd1667b.png)
