### PR TITLE
Add GFM todo snippet

### DIFF
--- a/snippets/gfm.cson
+++ b/snippets/gfm.cson
@@ -14,3 +14,6 @@
   'code':
     'prefix': 'code'
     'body': '```$1\n$2\n```$0'
+  'todo':
+    'prefix': 't'
+    'body': '- [ ] $1'


### PR DESCRIPTION
I originally tried something that would let a second tab jump into the `[ ]` box, but it proved to be buggy; tabbing from a subsequent item would jump back up to the `[ ]` box from the previous line:

``` coffee
'body': '- [${2: }] $1'
```

So I went with something simple as I doubt many people are writing already completed todos anyway.
### In JIFF form:

![lol](https://f.cloud.github.com/assets/475255/2479227/a24771f4-b092-11e3-8e7d-9a96c7fa6408.gif)
### Tests

There doesn't seem to be existing tests for any snippets, so I haven't written any for this. Happy to if I've missed something.
