### PR TITLE
Add Table Snippet

### DIFF
--- a/snippets/gfm.cson
+++ b/snippets/gfm.cson
@@ -17,3 +17,6 @@
   'todo':
     'prefix': 't'
     'body': '- [ ] $1'
+  'table':
+    'prefix': 'table'
+    'body': '| ${1:Header One    } | ${2:Header Two    } |\n| :------------- | :------------- |\n| ${3:Item One      } | ${4:Item Two      } |$0'


### PR DESCRIPTION
Expands `table` to:

```
| Header One     | Header Two     |
| :------------- | :------------- |
| Item One       | Item Two       |
```

Rather than leaving the cells blank I added tab stops that select the content in each of the cells. I thought tables are probably a less commonly known feature so an empty table might be a bit hard to understand.

![table](https://f.cloud.github.com/assets/475255/2489791/83a044f6-b178-11e3-81c6-62f995a71d06.gif)
