### PR TITLE
Match Mentions

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -394,7 +394,7 @@
         'name': 'comment.quote.gfm'
   }
   {
-    'match': '(?:^|\\s)(@)(\\w+)'
+    'match': '(?<=^|\\s)(@)(\\w+)'
     'captures':
       '1':
         'name': 'variable.mention.gfm'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -185,18 +185,23 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "sentence with no space before@name ", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("sentence with a space before @name that continues")
-    expect(tokens[0]).toEqual value: "sentence with a space before", scopes: ["source.gfm"]
+    expect(tokens[0]).toEqual value: "sentence with a space before ", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
+    expect(tokens[2]).toEqual value: "name", scopes: ["source.gfm", "string.username.gfm"]
+    expect(tokens[3]).toEqual value: " that continues", scopes: ["source.gfm"]
+
+    {tokens} = grammar.tokenizeLine("* @name at the start of an unordered list")
+    expect(tokens[0]).toEqual value: "*", scopes: ["source.gfm", "variable.unordered.list.gfm"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm"]
     expect(tokens[2]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
     expect(tokens[3]).toEqual value: "name", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[4]).toEqual value: " that continues", scopes: ["source.gfm"]
+    expect(tokens[4]).toEqual value: " at the start of an unordered list", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("a username @1337_bro with numbers, letters and underscores")
-    expect(tokens[0]).toEqual value: "a username", scopes: ["source.gfm"]
-    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm"]
-    expect(tokens[2]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
-    expect(tokens[3]).toEqual value: "1337_bro", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[4]).toEqual value: " with numbers, letters and underscores", scopes: ["source.gfm"]
+    expect(tokens[0]).toEqual value: "a username ", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
+    expect(tokens[2]).toEqual value: "1337_bro", scopes: ["source.gfm", "string.username.gfm"]
+    expect(tokens[3]).toEqual value: " with numbers, letters and underscores", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("@name at the start of a line")
     expect(tokens[0]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]


### PR DESCRIPTION
This matches mentions:

![screen shot 2014-03-26 at 9 57 20 am](https://f.cloud.github.com/assets/475255/2519424/8d559734-b471-11e3-9eae-ab94518d86d8.png)
### Couldn't work out

As mentioned in the screenshot; @names that are at the start of both ordered an unordered list items don't match. Presumably because it's right next to the `1.` or `*`, but there is whitespace between them which this regex matches against.
### I wasn't sure about

Using `variable` for the @ and `string` for the username. Perhaps the username could be `bold`. But neither seem semantic. I picked `variable` and `string` because it looks like they are used in other places so that any syntax colour scheme can be used.
### Follow up

As another PR I was thinking it'd be nice to match issues like #1 using a very similar regex.
