### PR TITLE
Match issues and be more specific with mentions

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -394,11 +394,19 @@
         'name': 'comment.quote.gfm'
   }
   {
-    'match': '(?<=^|\\s)(@)(\\w+)'
+    'match': '(?<=^|\\s)(@)(\\w+)(\\s|\')'
     'captures':
       '1':
         'name': 'variable.mention.gfm'
       '2':
         'name': 'string.username.gfm'
+  }
+  {
+    'match': '(?<=^|\\s)(#)([0-9]+)(\\s|\')'
+    'captures':
+      '1':
+        'name': 'variable.issuetag.gfm'
+      '2':
+        'name': 'string.issuenumber.gfm'
   }
 ]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -188,25 +188,29 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "sentence with a space before ", scopes: ["source.gfm"]
     expect(tokens[1]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
     expect(tokens[2]).toEqual value: "name", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[3]).toEqual value: " that continues", scopes: ["source.gfm"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.gfm"]
+    expect(tokens[4]).toEqual value: "that continues", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("* @name at the start of an unordered list")
     expect(tokens[0]).toEqual value: "*", scopes: ["source.gfm", "variable.unordered.list.gfm"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm"]
     expect(tokens[2]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
     expect(tokens[3]).toEqual value: "name", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[4]).toEqual value: " at the start of an unordered list", scopes: ["source.gfm"]
+    expect(tokens[4]).toEqual value: " ", scopes: ["source.gfm"]
+    expect(tokens[5]).toEqual value: "at the start of an unordered list", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("a username @1337_hubot with numbers, letters and underscores")
     expect(tokens[0]).toEqual value: "a username ", scopes: ["source.gfm"]
     expect(tokens[1]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
     expect(tokens[2]).toEqual value: "1337_hubot", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[3]).toEqual value: " with numbers, letters and underscores", scopes: ["source.gfm"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.gfm"]
+    expect(tokens[4]).toEqual value: "with numbers, letters and underscores", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("@name at the start of a line")
     expect(tokens[0]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
     expect(tokens[1]).toEqual value: "name", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[2]).toEqual value: " at the start of a line", scopes: ["source.gfm"]
+    expect(tokens[2]).toEqual value: " ", scopes: ["source.gfm"]
+    expect(tokens[3]).toEqual value: "at the start of a line", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("any email like you@domain.com shouldn't mistakenly be matched as a mention")
     expect(tokens[0]).toEqual value: "any email like you@domain.com shouldn't mistakenly be matched as a mention", scopes: ["source.gfm"]
@@ -214,7 +218,28 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("@person's")
     expect(tokens[0]).toEqual value: "@", scopes: ["source.gfm", "variable.mention.gfm"]
     expect(tokens[1]).toEqual value: "person", scopes: ["source.gfm", "string.username.gfm"]
-    expect(tokens[2]).toEqual value: "'s", scopes: ["source.gfm"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.gfm"]
+    expect(tokens[3]).toEqual value: "s", scopes: ["source.gfm"]
+
+  it "tokenizes issue numbers", ->
+    {tokens} = grammar.tokenizeLine("sentence with no space before#12 ")
+    expect(tokens[0]).toEqual value: "sentence with no space before#12 ", scopes: ["source.gfm"]
+
+    {tokens} = grammar.tokenizeLine("sentence with a space before #123i and a character after")
+    expect(tokens[0]).toEqual value: "sentence with a space before #123i and a character after", scopes: ["source.gfm"]
+
+    {tokens} = grammar.tokenizeLine("sentence with a space before #123 that continues")
+    expect(tokens[0]).toEqual value: "sentence with a space before ", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "#", scopes: ["source.gfm", "variable.issuetag.gfm"]
+    expect(tokens[2]).toEqual value: "123", scopes: ["source.gfm", "string.issuenumber.gfm"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.gfm"]
+    expect(tokens[4]).toEqual value: "that continues", scopes: ["source.gfm"]
+
+    {tokens} = grammar.tokenizeLine("#123's")
+    expect(tokens[0]).toEqual value: "#", scopes: ["source.gfm", "variable.issuetag.gfm"]
+    expect(tokens[1]).toEqual value: "123", scopes: ["source.gfm", "string.issuenumber.gfm"]
+    expect(tokens[2]).toEqual value: "'", scopes: ["source.gfm"]
+    expect(tokens[3]).toEqual value: "s", scopes: ["source.gfm"]
 
   it "tokenizes unordered lists", ->
     {tokens} = grammar.tokenizeLine("*Item 1")


### PR DESCRIPTION
This is just a follow up to the Match Mentions PR.
## Update to Match Mentions

``` diff
-    'match': '(?<=^|\\s)(@)(\\w+)'
+    'match': '(?<=^|\\s)(@)(\\w+)(\\s|\')'
```

The `(\\s|\')` on the end requires whitespace _or_ an apostrophe. This means you can say @bob's like GH allows, but no other special characters. I'm not sure if this scrictness is needed but seemed like a reasonable addition.
## Match Issues
- #9 matches the first issue.
- They can only have numbers so #yolo doesn't match. I wonder if this should be less strict so that issues can also double up as tags...?
- They can be followed by an apostrophe, e.g. "#14's changes".

This all works correctly in the editor:

![untitled_preview_-__users_andytlr_github_language-gfm](https://cloud.githubusercontent.com/assets/475255/2546042/edac7964-b628-11e3-8850-222a326dde4d.png)

Referencing issues breaks the [markdown-preview](https://github.com/atom/markdown-preview) as they're mistaken for headings. However, that's an issue with [markdown-preview](https://github.com/atom/markdown-preview).

![untitled_-__users_andytlr_github_language-gfm](https://cloud.githubusercontent.com/assets/475255/2546048/1870dd84-b629-11e3-9109-de5a031f5463.png)
