### PR TITLE
Don't mistake unordered lists for italic text

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -26,7 +26,11 @@
     'name': 'markup.bold.gfm'
   }
   {
-    'match': '(?<=^|\\s)(\\*[^\\*]+\\*)'
+    'match': '(?<=^)(\\*[^\\s\\*][^\\*]*\\*)'
+    'name': 'markup.italic.gfm'
+  }
+  {
+    'match': '(?<=\\s)(\\*[^\\*]+\\*)'
     'name': 'markup.italic.gfm'
   }
   {

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -68,6 +68,11 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("not*italic*")
     expect(tokens[0]).toEqual value: "not*italic*", scopes: ["source.gfm"]
 
+    {tokens} = grammar.tokenizeLine("* not *italic")
+    expect(tokens[0]).toEqual value: "*", scopes: ["source.gfm", "variable.unordered.list.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm"]
+    expect(tokens[2]).toEqual value: "not *italic", scopes: ["source.gfm"]
+
   it "tokenizes _italic_ text", ->
     {tokens} = grammar.tokenizeLine("__")
     expect(tokens[0]).toEqual value: "__", scopes: ["source.gfm"]


### PR DESCRIPTION
Currently, it's possible that unordered lists are confused for italic text. For example, this situation:

![screen shot 2014-05-02 at 2 13 26 pm](https://cloud.githubusercontent.com/assets/38924/2862504/fc683f92-d1f3-11e3-9ab8-06e8434e62c6.png)

should actually be parsed like this:

![screen shot 2014-05-02 at 2 12 32 pm](https://cloud.githubusercontent.com/assets/38924/2862505/0149bcb6-d1f4-11e3-8c5f-bc7b2a1203c4.png)

This PR massages the regex used to detect italic text formatted with `*`, and splits it into two cases to handle the `^* foo*` situation correctly.

cc @shawnyeager (thanks again for the report!)
