### PR TITLE
Add support for PHP, C# and Erlang in fenced code blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -305,6 +305,23 @@
     ]
   }
   {
+    'begin': '^\\s*`{3,}\\s*php\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*`{3,}$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.php.gfm'
+    'contentName': 'source.php'
+    'patterns': [
+      {
+        'include': 'source.php'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*`{3,}\\s*(sh|bash)\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
This fixes https://github.com/atom/markdown-preview/issues/75, fixes https://github.com/atom/markdown-preview/issues/79, and fixes https://github.com/atom/language-gfm/issues/23. 

BEFORE 

![screen shot 2014-05-10 at 6 53 53 pm](https://cloud.githubusercontent.com/assets/38924/2936700/1a8f93a2-d86c-11e3-9a40-1de3d90e0ba7.png)

AFTER

![screen shot 2014-05-10 at 3 59 46 pm](https://cloud.githubusercontent.com/assets/38924/2936696/da2e088e-d86b-11e3-9b70-8a9869b4e98d.png)

Note: this pull request adds highlighting for fenced code blocks in the editor only, not in the Markdown preview. I've made [a separate pull request for that](https://github.com/atom/markdown-preview/pull/80). Also, notice that PHP had support in Markdown preview, but not in language-gfm.
