### PR TITLE
Update HTML entities regex to accept numbers

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -109,7 +109,7 @@
         'name': 'string.emoji.end.gfm'
   }
   {
-    'match': '(&)[a-zA-Z]+(;)'
+    'match': '(&)[a-zA-Z0-9]+(;)'
     'name': 'constant.character.entity.gfm'
     'captures':
       '1':


### PR DESCRIPTION
Examples of entities with numbers: `&sup2;` and `&frac12;`
