### PR TITLE
Fix regex for ordered lists, number is required

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -464,7 +464,7 @@
         'name': 'variable.unordered.list.gfm'
   }
   {
-    'match': '^\\s*(\\d*\\.)[ \\t]+'
+    'match': '^\\s*(\\d+\\.)[ \\t]+'
     'captures':
       '1':
         'name': 'variable.ordered.list.gfm'


### PR DESCRIPTION
The current regex allows for a list item without a number, which is
invalid:

. This is not a list

Using + we force at least one digit before the dot.
