### PR TITLE
Add multiline support for bold, italic and bold-italic

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -30,15 +30,13 @@
     'name': 'markup.bold.gfm'
   }
   {
-    'match': '(?<=^)(\\*[^\\s\\*][^*]*\\*)'
+    'begin': '(?<=^|\\s)\\*(?!$|\\*|\\s)'
+    'end': '\\*'
     'name': 'markup.italic.gfm'
   }
   {
-    'match': '(?<=\\s)(\\*[^*]+\\*)'
-    'name': 'markup.italic.gfm'
-  }
-  {
-    'match': '(?<=^|\\s)(_[^_]+_)'
+    'begin': '(?<=^|\\s)_(?!$|_|\\s)'
+    'end': '_'
     'name': 'markup.italic.gfm'
   }
   {

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -98,16 +98,26 @@ describe "GitHub Flavored Markdown grammar", ->
 
     {tokens} = grammar.tokenizeLine("this is *italic* text")
     expect(tokens[0]).toEqual value: "this is ", scopes: ["source.gfm"]
-    expect(tokens[1]).toEqual value: "*italic*", scopes: ["source.gfm", "markup.italic.gfm"]
-    expect(tokens[2]).toEqual value: " text", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "*", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(tokens[2]).toEqual value: "italic", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(tokens[3]).toEqual value: "*", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(tokens[4]).toEqual value: " text", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("not*italic*")
     expect(tokens[0]).toEqual value: "not*italic*", scopes: ["source.gfm"]
 
-    {tokens} = grammar.tokenizeLine("* not *italic")
+    {tokens} = grammar.tokenizeLine("* not italic")
     expect(tokens[0]).toEqual value: "*", scopes: ["source.gfm", "variable.unordered.list.gfm"]
     expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm"]
-    expect(tokens[2]).toEqual value: "not *italic", scopes: ["source.gfm"]
+    expect(tokens[2]).toEqual value: "not italic", scopes: ["source.gfm"]
+
+    [firstLineTokens, secondLineTokens] = grammar.tokenizeLines("this is *ita\nlic*!")
+    expect(firstLineTokens[0]).toEqual value: "this is ", scopes: ["source.gfm"]
+    expect(firstLineTokens[1]).toEqual value: "*", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(firstLineTokens[2]).toEqual value: "ita", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(secondLineTokens[0]).toEqual value: "lic", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(secondLineTokens[1]).toEqual value: "*", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(secondLineTokens[2]).toEqual value: "!", scopes: ["source.gfm"]
 
   it "tokenizes _italic_ text", ->
     {tokens} = grammar.tokenizeLine("__")
@@ -115,11 +125,21 @@ describe "GitHub Flavored Markdown grammar", ->
 
     {tokens} = grammar.tokenizeLine("this is _italic_ text")
     expect(tokens[0]).toEqual value: "this is ", scopes: ["source.gfm"]
-    expect(tokens[1]).toEqual value: "_italic_", scopes: ["source.gfm", "markup.italic.gfm"]
-    expect(tokens[2]).toEqual value: " text", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "_", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(tokens[2]).toEqual value: "italic", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(tokens[3]).toEqual value: "_", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(tokens[4]).toEqual value: " text", scopes: ["source.gfm"]
 
     {tokens} = grammar.tokenizeLine("not_italic_")
     expect(tokens[0]).toEqual value: "not_italic_", scopes: ["source.gfm"]
+
+    [firstLineTokens, secondLineTokens] = grammar.tokenizeLines("this is _ita\nlic_!")
+    expect(firstLineTokens[0]).toEqual value: "this is ", scopes: ["source.gfm"]
+    expect(firstLineTokens[1]).toEqual value: "_", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(firstLineTokens[2]).toEqual value: "ita", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(secondLineTokens[0]).toEqual value: "lic", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(secondLineTokens[1]).toEqual value: "_", scopes: ["source.gfm", "markup.italic.gfm"]
+    expect(secondLineTokens[2]).toEqual value: "!", scopes: ["source.gfm"]
 
   it "tokenizes headings", ->
     {tokens} = grammar.tokenizeLine("# Heading 1")
@@ -338,7 +358,7 @@ describe "GitHub Flavored Markdown grammar", ->
 
   it "tokenizes unordered lists", ->
     {tokens} = grammar.tokenizeLine("*Item 1")
-    expect(tokens[0]).toEqual value: "*Item 1", scopes: ["source.gfm"]
+    expect(tokens[0]).not.toEqual value: "*Item 1", scopes: ["source.gfm", "variable.unordered.list.gfm"]
 
     {tokens} = grammar.tokenizeLine("  * Item 1")
     expect(tokens[0]).toEqual value: "  ", scopes: ["source.gfm"]


### PR DESCRIPTION
This adds multi-line support for bold, italic and bold-italic. For example...

``` markdown
*ita
lic*
```

...will now render the syntax correctly.

Closes #19
