### PR TITLE
Correct tokenization of id-less reference links.

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -542,7 +542,7 @@
         'name': 'markup.underline.link.gfm'
   }
   {
-    'match': '!?\\[([^\\]]*)\\]\\[([^\\]]+)\\]'
+    'match': '!?\\[([^\\]]*)\\]\\[([^\\]]*)\\]'
     'name': 'link'
     'captures':
       '1':

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -265,7 +265,7 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[4]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
     expect(tokens[5]).toEqual value: ")", scopes: ["source.gfm", "link"]
 
-  it "tokenizes [links][links]", ->
+  it "tokenizes reference [links][links]", ->
     {tokens} = grammar.tokenizeLine("please click [this link][website]")
     expect(tokens[0]).toEqual value: "please click ", scopes: ["source.gfm"]
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link"]
@@ -273,6 +273,13 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[3]).toEqual value: "][", scopes: ["source.gfm", "link"]
     expect(tokens[4]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
     expect(tokens[5]).toEqual value: "]", scopes: ["source.gfm", "link"]
+
+  it "tokenizes id-less reference [links][]", ->
+    {tokens} = grammar.tokenizeLine("please click [this link][]")
+    expect(tokens[0]).toEqual value: "please click ", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link"]
+    expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
+    expect(tokens[3]).toEqual value: "][]", scopes: ["source.gfm", "link"]
 
   it "tokenizes [link]: footers", ->
     {tokens} = grammar.tokenizeLine("[aLink]: http://website")


### PR DESCRIPTION
- This is an acceptable style of id-less (or implicit-id'd) reference
  links:

``` gfm
[This][] is an acceptable way to define reference links. The
reference list "id" is the inferred from the link text.

[This]: http://daringfireball.net/projects/markdown/syntax#link
```
- Added and renamed tests to better describe behavior.
