### PR TITLE
recognise double-space linebreaks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -629,6 +629,12 @@
         'name': 'string.issue.number.gfm'
   }
   {
+    'match': '(  )$'
+    'captures':
+      '1':
+        'name': 'linebreak.gfm'
+  }
+  {
     'begin': '<!--'
     'captures':
       '0':

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -555,3 +555,8 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(firstLineTokens[0]).toEqual value: "---", scopes: ["source.gfm", "front-matter.yaml.gfm", "comment.hr.gfm"]
     expect(secondLineTokens[0]).toEqual value: "front: matter", scopes: ["source.gfm", "front-matter.yaml.gfm"]
     expect(thirdLineTokens[0]).toEqual value: "---", scopes: ["source.gfm", "front-matter.yaml.gfm", "comment.hr.gfm"]
+
+  it "tokenizes linebreaks", ->
+    {tokens} = grammar.tokenizeLine("line  \n")
+    expect(tokens[0]).toEqual value: "line", scopes: ["source.gfm"]
+    expect(tokens[1]).toEqual value: "  ", scopes: ["source.gfm", "linebreak.gfm"]


### PR DESCRIPTION
Two spaces at the end of a line are treated as a <br> line break. It would be nice if a syntax theme were able to recognise and style this. 
![screen shot 2014-12-30 at 13 40 25](https://cloud.githubusercontent.com/assets/2543659/5578527/76bb17e4-9029-11e4-9965-ea7bae55c70d.png)
