### PR TITLE
Punctuation for links

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -526,65 +526,131 @@
     'name': 'markup.raw.gfm'
   }
   {
-    'match': '\\[!\\[([^\\]]*)\\]\\(([^\\)]+)\\)\\](\\(([^\\)]+)\\)|\\[([^\\]]+)\\])'
+    'match': '(\\[!)(\\[)([^\\]]*)(\\])(\\()([^\\)]+)(\\))(\\])((\\()([^\\)]+)(\\))|(\\[)([^\\]]+)(\\]))'
     'name': 'link'
     'captures':
       '1':
-        'name': 'entity.gfm'
+        'name': 'punctuation.definition.begin.gfm'
       '2':
-        'name': 'markup.underline.link.gfm'
+        'name': 'punctuation.definition.begin.gfm'
+      '3':
+        'name': 'entity.gfm'
       '4':
+        'name': 'punctuation.definition.end.gfm'
+      '5':
+        'name': 'punctuation.definition.begin.gfm'
+      '6':
         'name': 'markup.underline.link.gfm'
+      '7':
+        'name': 'punctuation.definition.end.gfm'
+      '8':
+        'name': 'punctuation.definition.begin.gfm'
+      '10':
+        'name': 'punctuation.definition.begin.gfm'
+      '11':
+        'name': 'markup.underline.link.gfm'
+      '12':
+        'name': 'punctuation.definition.end.gfm'
+      '13':
+        'name': 'punctuation.definition.begin.gfm'
+      '14':
+        'name': 'markup.underline.link.gfm'
+      '15':
+        'name': 'punctuation.definition.end.gfm'
+  }
+  {
+    'match': '(\\[!)(\\[)([^\\]]*)(\\])(\\[)([^\\)]+)(\\])(\\])((\\()([^\\)]+)(\\))|(\\[)([^\\]]+)(\\]))'
+    'name': 'link'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.begin.gfm'
+      '2':
+        'name': 'punctuation.definition.begin.gfm'
+      '3':
+        'name': 'entity.gfm'
+      '4':
+        'name': 'punctuation.definition.end.gfm'
+      '5':
+        'name': 'punctuation.definition.begin.gfm'
+      '6':
+        'name': 'markup.underline.link.gfm'
+      '7':
+        'name': 'punctuation.definition.end.gfm'
+      '8':
+        'name': 'punctuation.definition.begin.gfm'
+      '10':
+        'name': 'punctuation.definition.begin.gfm'
+      '11':
+        'name': 'markup.underline.link.gfm'
+      '12':
+        'name': 'punctuation.definition.end.gfm'
+      '13':
+        'name': 'punctuation.definition.begin.gfm'
+      '14':
+        'name': 'markup.underline.link.gfm'
+      '15':
+        'name': 'punctuation.definition.end.gfm'
+  }
+  {
+    'match': '!?(\\[)([^\\]]*)(\\])(\\()([^\\)]+)(\\))'
+    'name': 'link'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.begin.gfm'
+      '2':
+        'name': 'entity.gfm'
+      '3':
+        'name': 'punctuation.definition.end.gfm'
+      '4':
+        'name': 'punctuation.definition.begin.gfm'
       '5':
         'name': 'markup.underline.link.gfm'
+      '6':
+        'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '\\[!\\[([^\\]]*)\\]\\[([^\\]]+)\\]\\](\\(([^\\)]+)\\)|\\[([^\\]]+)\\])'
+    'match': '!?(\\[)([^\\]]*)(\\])(\\[)([^\\]]*)(\\])'
     'name': 'link'
     'captures':
       '1':
-        'name': 'entity.gfm'
+        'name': 'punctuation.definition.begin.gfm'
       '2':
-        'name': 'markup.underline.link.gfm'
+        'name': 'entity.gfm'
+      '3':
+        'name': 'punctuation.definition.end.gfm'
       '4':
-        'name': 'markup.underline.link.gfm'
+        'name': 'punctuation.definition.begin.gfm'
       '5':
         'name': 'markup.underline.link.gfm'
+      '6':
+        'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '!?\\[([^\\]]*)\\]\\(([^\\)]+)\\)'
+    'match': '^\\s*(\\[)([^\\]]+)(\\])\\s*:\\s*<([^>]+)>'
     'name': 'link'
     'captures':
       '1':
-        'name': 'entity.gfm'
+        'name': 'punctuation.definition.begin.gfm'
       '2':
+        'name': 'entity.gfm'
+      '3':
+        'name': 'punctuation.definition.end.gfm'
+      '4':
         'name': 'markup.underline.link.gfm'
   }
   {
-    'match': '!?\\[([^\\]]*)\\]\\[([^\\]]*)\\]'
+    'match': '^\\s*(\\[)([^\\]]+)(\\])\\s*(:)\\s*(\\S+)'
     'name': 'link'
     'captures':
       '1':
-        'name': 'entity.gfm'
+        'name': 'punctuation.definition.begin.gfm'
       '2':
-        'name': 'markup.underline.link.gfm'
-  }
-  {
-    'match': '^\\s*\\[([^\\]]+)\\]\\s*:\\s*<([^>]+)>'
-    'name': 'link'
-    'captures':
-      '1':
         'name': 'entity.gfm'
-      '2':
-        'name': 'markup.underline.link.gfm'
-  }
-  {
-    'match': '^\\s*\\[([^\\]]+)\\]\\s*:\\s*(\\S+)'
-    'name': 'link'
-    'captures':
-      '1':
-        'name': 'entity.gfm'
-      '2':
+      '3':
+        'name': 'punctuation.definition.end.gfm'
+      '4':
+        'name': 'punctuation.separator.key-value.gfm'
+      '5':
         'name': 'markup.underline.link.gfm'
   }
   {

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -526,7 +526,7 @@
     'name': 'markup.raw.gfm'
   }
   {
-    'match': '(\\[!)(\\[)([^\\]]*)(\\])(\\()([^\\)]+)(\\))(\\])((\\()([^\\)]+)(\\))|(\\[)([^\\]]+)(\\]))'
+    'match': '(\\[!)(\\[)([^\\]]*)(\\])((\\()[^\\)]+(\\)))(\\])(((\\()[^\\)]+(\\)))|((\\[)[^\\]]+(\\])))'
     'name': 'link'
     'captures':
       '1':
@@ -538,28 +538,28 @@
       '4':
         'name': 'punctuation.definition.end.gfm'
       '5':
-        'name': 'punctuation.definition.begin.gfm'
-      '6':
         'name': 'markup.underline.link.gfm'
+      '6':
+        'name': 'punctuation.definition.begin.gfm'
       '7':
         'name': 'punctuation.definition.end.gfm'
       '8':
-        'name': 'punctuation.definition.begin.gfm'
+        'name': 'punctuation.definition.end.gfm'
       '10':
-        'name': 'punctuation.definition.begin.gfm'
-      '11':
         'name': 'markup.underline.link.gfm'
+      '11':
+        'name': 'punctuation.definition.begin.gfm'
       '12':
         'name': 'punctuation.definition.end.gfm'
       '13':
-        'name': 'punctuation.definition.begin.gfm'
-      '14':
         'name': 'markup.underline.link.gfm'
+      '14':
+        'name': 'punctuation.definition.begin.gfm'
       '15':
         'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '(\\[!)(\\[)([^\\]]*)(\\])(\\[)([^\\)]+)(\\])(\\])((\\()([^\\)]+)(\\))|(\\[)([^\\]]+)(\\]))'
+    'match': '(\\[!)(\\[)([^\\]]*)(\\])((\\[)[^\\)]+(\\]))(\\])(((\\()[^\\)]+(\\)))|((\\[)[^\\]]+(\\])))'
     'name': 'link'
     'captures':
       '1':
@@ -571,28 +571,28 @@
       '4':
         'name': 'punctuation.definition.end.gfm'
       '5':
-        'name': 'punctuation.definition.begin.gfm'
-      '6':
         'name': 'markup.underline.link.gfm'
+      '6':
+        'name': 'punctuation.definition.begin.gfm'
       '7':
         'name': 'punctuation.definition.end.gfm'
       '8':
-        'name': 'punctuation.definition.begin.gfm'
+        'name': 'punctuation.definition.end.gfm'
       '10':
-        'name': 'punctuation.definition.begin.gfm'
-      '11':
         'name': 'markup.underline.link.gfm'
+      '11':
+        'name': 'punctuation.definition.begin.gfm'
       '12':
         'name': 'punctuation.definition.end.gfm'
       '13':
-        'name': 'punctuation.definition.begin.gfm'
-      '14':
         'name': 'markup.underline.link.gfm'
+      '14':
+        'name': 'punctuation.definition.begin.gfm'
       '15':
         'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '!?(\\[)([^\\]]*)(\\])(\\()([^\\)]+)(\\))'
+    'match': '!?(\\[)([^\\]]*)(\\])((\\()[^\\)]+(\\)))'
     'name': 'link'
     'captures':
       '1':
@@ -602,14 +602,14 @@
       '3':
         'name': 'punctuation.definition.end.gfm'
       '4':
-        'name': 'punctuation.definition.begin.gfm'
-      '5':
         'name': 'markup.underline.link.gfm'
+      '5':
+        'name': 'punctuation.definition.begin.gfm'
       '6':
         'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '!?(\\[)([^\\]]*)(\\])(\\[)([^\\]]*)(\\])'
+    'match': '!?(\\[)([^\\]]*)(\\])((\\[)[^\\]]*(\\]))'
     'name': 'link'
     'captures':
       '1':
@@ -619,9 +619,9 @@
       '3':
         'name': 'punctuation.definition.end.gfm'
       '4':
-        'name': 'punctuation.definition.begin.gfm'
-      '5':
         'name': 'markup.underline.link.gfm'
+      '5':
+        'name': 'punctuation.definition.begin.gfm'
       '6':
         'name': 'punctuation.definition.end.gfm'
   }

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -259,83 +259,105 @@ describe "GitHub Flavored Markdown grammar", ->
   it "tokenizes [links](links)", ->
     {tokens} = grammar.tokenizeLine("please click [this link](website)")
     expect(tokens[0]).toEqual value: "please click ", scopes: ["source.gfm"]
-    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[3]).toEqual value: "](", scopes: ["source.gfm", "link"]
-    expect(tokens[4]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[5]).toEqual value: ")", scopes: ["source.gfm", "link"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes reference [links][links]", ->
     {tokens} = grammar.tokenizeLine("please click [this link][website]")
     expect(tokens[0]).toEqual value: "please click ", scopes: ["source.gfm"]
-    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[3]).toEqual value: "][", scopes: ["source.gfm", "link"]
-    expect(tokens[4]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[5]).toEqual value: "]", scopes: ["source.gfm", "link"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes id-less reference [links][]", ->
     {tokens} = grammar.tokenizeLine("please click [this link][]")
     expect(tokens[0]).toEqual value: "please click ", scopes: ["source.gfm"]
-    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[3]).toEqual value: "][]", scopes: ["source.gfm", "link"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes [link]: footers", ->
     {tokens} = grammar.tokenizeLine("[aLink]: http://website")
-    expect(tokens[0]).toEqual value: "[", scopes: ["source.gfm", "link"]
+    expect(tokens[0]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[1]).toEqual value: "aLink", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[2]).toEqual value: "]: ", scopes: ["source.gfm", "link"]
-    expect(tokens[3]).toEqual value: "http://website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[2]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[3]).toEqual value: ":", scopes: ["source.gfm", "link", "punctuation.separator.key-value.gfm"]
+    expect(tokens[4]).toEqual value: " ", scopes: ["source.gfm", "link"]
+    expect(tokens[5]).toEqual value: "http://website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
 
   it "tokenizes [link]: <footers>", ->
     {tokens} = grammar.tokenizeLine("[aLink]: <http://website>")
-    expect(tokens[0]).toEqual value: "[", scopes: ["source.gfm", "link"]
+    expect(tokens[0]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[1]).toEqual value: "aLink", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[2]).toEqual value: "]: <", scopes: ["source.gfm", "link"]
-    expect(tokens[3]).toEqual value: "http://website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[4]).toEqual value: ">", scopes: ["source.gfm", "link"]
+    expect(tokens[2]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[3]).toEqual value: ": <", scopes: ["source.gfm", "link"]
+    expect(tokens[4]).toEqual value: "http://website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[5]).toEqual value: ">", scopes: ["source.gfm", "link"]
 
   it "tokenizes [![links](links)](links)", ->
     {tokens} = grammar.tokenizeLine("[![title](image)](link)")
-    expect(tokens[0]).toEqual value: "[![", scopes: ["source.gfm", "link"]
-    expect(tokens[1]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[2]).toEqual value: "](", scopes: ["source.gfm", "link"]
-    expect(tokens[3]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[4]).toEqual value: ")](", scopes: ["source.gfm", "link"]
-    expect(tokens[5]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link"]
+    expect(tokens[0]).toEqual value: "[!", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[8]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[10]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes [![links](links)][links]", ->
     {tokens} = grammar.tokenizeLine("[![title](image)][link]")
-    expect(tokens[0]).toEqual value: "[![", scopes: ["source.gfm", "link"]
-    expect(tokens[1]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[2]).toEqual value: "](", scopes: ["source.gfm", "link"]
-    expect(tokens[3]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[4]).toEqual value: ")][", scopes: ["source.gfm", "link"]
-    expect(tokens[5]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link"]
+    expect(tokens[0]).toEqual value: "[!", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[8]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[10]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes [![links][links]](links)", ->
     {tokens} = grammar.tokenizeLine("[![title][image]](link)")
-    expect(tokens[0]).toEqual value: "[![", scopes: ["source.gfm", "link"]
-    expect(tokens[1]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[2]).toEqual value: "][", scopes: ["source.gfm", "link"]
-    expect(tokens[3]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[4]).toEqual value: "]](", scopes: ["source.gfm", "link"]
-    expect(tokens[5]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link"]
+    expect(tokens[0]).toEqual value: "[!", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[8]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[10]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes [![links][links]][links]", ->
     {tokens} = grammar.tokenizeLine("[![title][image]][link]")
-    expect(tokens[0]).toEqual value: "[![", scopes: ["source.gfm", "link"]
-    expect(tokens[1]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
-    expect(tokens[2]).toEqual value: "][", scopes: ["source.gfm", "link"]
-    expect(tokens[3]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[4]).toEqual value: "]][", scopes: ["source.gfm", "link"]
-    expect(tokens[5]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link"]
-
+    expect(tokens[0]).toEqual value: "[!", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
+    expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
+    expect(tokens[8]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
+    expect(tokens[10]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
 
   it "tokenizes mentions", ->
     {tokens} = grammar.tokenizeLine("sentence with no space before@name ")


### PR DESCRIPTION
It would be nice if punctuation could be styled separately. I feel like there should be a more efficient way to code this, but hey... 

![screen shot 2014-12-30 at 13 58 29](https://cloud.githubusercontent.com/assets/2543659/5578668/17dc3160-902c-11e4-81ba-95595bb2d3bd.png)
