### PR TITLE
Apply GFM language to plain text documents

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -8,6 +8,7 @@
   'mkdown'
   'rmd'
   'ron'
+  'txt'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Likely to be controversial, but.

Let's apply the GFM language to .txt files. One virtue of Markdown is that it degrades gracefully to plain text. Why hamstring it by requiring a boutique file extension?