### PR TITLE
Add captures for headers

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -50,12 +50,14 @@
     'name': 'markup.strike.gfm'
   }
   {
-    'begin': '^(#{6}\\s*)'
+    'begin': '^(#{6})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-6.gfm'
     'captures':
       '1':
         'name': 'markup.heading.marker.gfm'
+      '2':
+        'name': 'markup.heading.space.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -63,12 +65,14 @@
     ]
   }
   {
-    'begin': '^(#{5}\\s*)'
+    'begin': '^(#{5})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-5.gfm'
     'captures':
       '1':
         'name': 'markup.heading.marker.gfm'
+      '2':
+        'name': 'markup.heading.space.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -76,12 +80,14 @@
     ]
   }
   {
-    'begin': '^(#{4}\\s*)'
+    'begin': '^(#{4})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-4.gfm'
     'captures':
       '1':
         'name': 'markup.heading.marker.gfm'
+      '2':
+        'name': 'markup.heading.space.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -89,12 +95,14 @@
     ]
   }
   {
-    'begin': '^(#{3}\\s*)'
+    'begin': '^(#{3})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-3.gfm'
     'captures':
       '1':
         'name': 'markup.heading.marker.gfm'
+      '2':
+        'name': 'markup.heading.space.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -102,12 +110,14 @@
     ]
   }
   {
-    'begin': '^(#{2}\\s*)'
+    'begin': '^(#{2})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-2.gfm'
     'captures':
       '1':
         'name': 'markup.heading.marker.gfm'
+      '2':
+        'name': 'markup.heading.space.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -115,12 +125,14 @@
     ]
   }
   {
-    'begin': '^(#{1}\\s*)'
+    'begin': '^(#{1})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-1.gfm'
     'captures':
       '1':
         'name': 'markup.heading.marker.gfm'
+      '2':
+        'name': 'markup.heading.space.gfm'
     'patterns': [
       {
         'include': '$self'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -50,7 +50,7 @@
     'name': 'markup.strike.gfm'
   }
   {
-    'begin': '^(#{6})\\s*'
+    'begin': '^(#{6}\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-6.gfm'
     'captures':
@@ -63,7 +63,7 @@
     ]
   }
   {
-    'begin': '^(#{5})\\s*'
+    'begin': '^(#{5}\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-5.gfm'
     'captures':
@@ -76,7 +76,7 @@
     ]
   }
   {
-    'begin': '^(#{4})\\s*'
+    'begin': '^(#{4}\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-4.gfm'
     'captures':
@@ -89,7 +89,7 @@
     ]
   }
   {
-    'begin': '^(#{3})\\s*'
+    'begin': '^(#{3}\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-3.gfm'
     'captures':
@@ -102,7 +102,7 @@
     ]
   }
   {
-    'begin': '^(#{2})\\s*'
+    'begin': '^(#{2}\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-2.gfm'
     'captures':
@@ -115,7 +115,7 @@
     ]
   }
   {
-    'begin': '^(#{1})\\s*'
+    'begin': '^(#{1}\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-1.gfm'
     'captures':

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -50,9 +50,12 @@
     'name': 'markup.strike.gfm'
   }
   {
-    'begin': '^#{6}\\s*'
+    'begin': '^(#{6})\\s*'
     'end': '$'
     'name': 'markup.heading.heading-6.gfm'
+    'captures':
+      '1':
+        'name': 'markup.heading.marker.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -60,9 +63,12 @@
     ]
   }
   {
-    'begin': '^#{5}\\s*'
+    'begin': '^(#{5})\\s*'
     'end': '$'
     'name': 'markup.heading.heading-5.gfm'
+    'captures':
+      '1':
+        'name': 'markup.heading.marker.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -70,9 +76,12 @@
     ]
   }
   {
-    'begin': '^#{4}\\s*'
+    'begin': '^(#{4})\\s*'
     'end': '$'
     'name': 'markup.heading.heading-4.gfm'
+    'captures':
+      '1':
+        'name': 'markup.heading.marker.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -80,9 +89,12 @@
     ]
   }
   {
-    'begin': '^#{3}\\s*'
+    'begin': '^(#{3})\\s*'
     'end': '$'
     'name': 'markup.heading.heading-3.gfm'
+    'captures':
+      '1':
+        'name': 'markup.heading.marker.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -90,9 +102,12 @@
     ]
   }
   {
-    'begin': '^#{2}\\s*'
+    'begin': '^(#{2})\\s*'
     'end': '$'
     'name': 'markup.heading.heading-2.gfm'
+    'captures':
+      '1':
+        'name': 'markup.heading.marker.gfm'
     'patterns': [
       {
         'include': '$self'
@@ -100,9 +115,12 @@
     ]
   }
   {
-    'begin': '^#{1}\\s*'
+    'begin': '^(#{1})\\s*'
     'end': '$'
     'name': 'markup.heading.heading-1.gfm'
+    'captures':
+      '1':
+        'name': 'markup.heading.marker.gfm'
     'patterns': [
       {
         'include': '$self'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -174,42 +174,45 @@ describe "GitHub Flavored Markdown grammar", ->
 
   it "tokenizes headings", ->
     {tokens} = grammar.tokenizeLine("# Heading 1")
-    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[0]).toEqual value: "#", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
 
     {tokens} = grammar.tokenizeLine("## Heading 2")
-    expect(tokens[0]).toEqual value: "## ", scopes: ["source.gfm", "markup.heading.heading-2.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 2", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
+    expect(tokens[0]).toEqual value: "##", scopes: ["source.gfm", "markup.heading.heading-2.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-2.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading 2", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
 
     {tokens} = grammar.tokenizeLine("### Heading 3")
-    expect(tokens[0]).toEqual value: "### ", scopes: ["source.gfm", "markup.heading.heading-3.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 3", scopes: ["source.gfm", "markup.heading.heading-3.gfm"]
+    expect(tokens[0]).toEqual value: "###", scopes: ["source.gfm", "markup.heading.heading-3.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-3.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading 3", scopes: ["source.gfm", "markup.heading.heading-3.gfm"]
 
     {tokens} = grammar.tokenizeLine("#### Heading 4")
-    expect(tokens[0]).toEqual value: "#### ", scopes: ["source.gfm", "markup.heading.heading-4.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 4", scopes: ["source.gfm", "markup.heading.heading-4.gfm"]
+    expect(tokens[0]).toEqual value: "####", scopes: ["source.gfm", "markup.heading.heading-4.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-4.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading 4", scopes: ["source.gfm", "markup.heading.heading-4.gfm"]
 
     {tokens} = grammar.tokenizeLine("##### Heading 5")
-    expect(tokens[0]).toEqual value: "##### ", scopes: ["source.gfm", "markup.heading.heading-5.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 5", scopes: ["source.gfm", "markup.heading.heading-5.gfm"]
+    expect(tokens[0]).toEqual value: "#####", scopes: ["source.gfm", "markup.heading.heading-5.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-5.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading 5", scopes: ["source.gfm", "markup.heading.heading-5.gfm"]
 
     {tokens} = grammar.tokenizeLine("###### Heading 6")
-    expect(tokens[0]).toEqual value: "###### ", scopes: ["source.gfm", "markup.heading.heading-6.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 6", scopes: ["source.gfm", "markup.heading.heading-6.gfm"]
+    expect(tokens[0]).toEqual value: "######", scopes: ["source.gfm", "markup.heading.heading-6.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-6.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading 6", scopes: ["source.gfm", "markup.heading.heading-6.gfm"]
 
-    {tokens} = grammar.tokenizeLine("#Heading 1")
-    expect(tokens[0]).toEqual value: "#", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
-
-  it "tokenzies matches inside of headers", ->
+  it "tokenizes matches inside of headers", ->
     {tokens} = grammar.tokenizeLine("# Heading :one:")
-    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
-    expect(tokens[1]).toEqual value: "Heading ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
-    expect(tokens[2]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.start.gfm"]
-    expect(tokens[3]).toEqual value: "one", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.word.gfm"]
-    expect(tokens[4]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.end.gfm"]
+    expect(tokens[0]).toEqual value: "#", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.space.gfm"]
+    expect(tokens[2]).toEqual value: "Heading ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[3]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.start.gfm"]
+    expect(tokens[4]).toEqual value: "one", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.word.gfm"]
+    expect(tokens[5]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.end.gfm"]
 
-  it "tokenizies an :emoji:", ->
+  it "tokenizes an :emoji:", ->
     {tokens} = grammar.tokenizeLine("this is :no_good:")
     expect(tokens[0]).toEqual value: "this is ", scopes: ["source.gfm"]
     expect(tokens[1]).toEqual value: ":", scopes: ["source.gfm", "string.emoji.gfm", "string.emoji.start.gfm"]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -178,7 +178,7 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
 
     {tokens} = grammar.tokenizeLine("## Heading 2")
-    expect(tokens[0]).toEqual value: "## ", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
+    expect(tokens[0]).toEqual value: "## ", scopes: ["source.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 2", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
 
     {tokens} = grammar.tokenizeLine("### Heading 3")

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -174,36 +174,36 @@ describe "GitHub Flavored Markdown grammar", ->
 
   it "tokenizes headings", ->
     {tokens} = grammar.tokenizeLine("# Heading 1")
-    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
 
     {tokens} = grammar.tokenizeLine("## Heading 2")
-    expect(tokens[0]).toEqual value: "## ", scopes: ["source.gfm", "markup.heading.marker.gfm"]
+    expect(tokens[0]).toEqual value: "## ", scopes: ["source.gfm", "markup.heading.heading-2.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 2", scopes: ["source.gfm", "markup.heading.heading-2.gfm"]
 
     {tokens} = grammar.tokenizeLine("### Heading 3")
-    expect(tokens[0]).toEqual value: "### ", scopes: ["source.gfm", "markup.heading.heading-3.gfm"]
+    expect(tokens[0]).toEqual value: "### ", scopes: ["source.gfm", "markup.heading.heading-3.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 3", scopes: ["source.gfm", "markup.heading.heading-3.gfm"]
 
     {tokens} = grammar.tokenizeLine("#### Heading 4")
-    expect(tokens[0]).toEqual value: "#### ", scopes: ["source.gfm", "markup.heading.heading-4.gfm"]
+    expect(tokens[0]).toEqual value: "#### ", scopes: ["source.gfm", "markup.heading.heading-4.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 4", scopes: ["source.gfm", "markup.heading.heading-4.gfm"]
 
     {tokens} = grammar.tokenizeLine("##### Heading 5")
-    expect(tokens[0]).toEqual value: "##### ", scopes: ["source.gfm", "markup.heading.heading-5.gfm"]
+    expect(tokens[0]).toEqual value: "##### ", scopes: ["source.gfm", "markup.heading.heading-5.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 5", scopes: ["source.gfm", "markup.heading.heading-5.gfm"]
 
     {tokens} = grammar.tokenizeLine("###### Heading 6")
-    expect(tokens[0]).toEqual value: "###### ", scopes: ["source.gfm", "markup.heading.heading-6.gfm"]
+    expect(tokens[0]).toEqual value: "###### ", scopes: ["source.gfm", "markup.heading.heading-6.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 6", scopes: ["source.gfm", "markup.heading.heading-6.gfm"]
 
     {tokens} = grammar.tokenizeLine("#Heading 1")
-    expect(tokens[0]).toEqual value: "#", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[0]).toEqual value: "#", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading 1", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
 
   it "tokenzies matches inside of headers", ->
     {tokens} = grammar.tokenizeLine("# Heading :one:")
-    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
+    expect(tokens[0]).toEqual value: "# ", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "markup.heading.marker.gfm"]
     expect(tokens[1]).toEqual value: "Heading ", scopes: ["source.gfm", "markup.heading.heading-1.gfm"]
     expect(tokens[2]).toEqual value: ":", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.start.gfm"]
     expect(tokens[3]).toEqual value: "one", scopes: ["source.gfm", "markup.heading.heading-1.gfm", "string.emoji.gfm", "string.emoji.word.gfm"]


### PR DESCRIPTION
The `#` symbols have the `.markup.marker` style, which allows to style them
differently from the rest of the heading.

This is a mostly cosmetic change, but it allows to highlight the text differently from the markup. See below. If the theme is not specifying anything for the `.markup.marker` style, then nothing happpens.

![capture d ecran de 2015-04-14 11 17 51](https://cloud.githubusercontent.com/assets/579329/7140165/edbdd19a-e297-11e4-8ba7-e390a9a4bf7f.png)

I haven't written the full specs yet, so this PR is to get comments / feedback. If this has any chance of being merged, I'll work on the specs (which should be really easy).