### PR TITLE
Improving the italic and bold styles

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -15,34 +15,28 @@
     'name': 'constant.character.escape.gfm'
   }
   {
-    'begin': '(?<=^|[^\\w\\d\\*])\\*\\*\\*(?!$|\\*|\\s)'
-    'end': '(?<!^|\\s)\\*\\*\\**\\*(?=$|[^\\w|\\d])'
-    'name': 'markup.bold.italic.gfm'
+    'match': '^___([\\s\\S]+?)___(?!_)|^\\*\\*\\*([\\s\\S]+?)\\*\\*\\*(?!\\*)'
+    'captures':
+      '1':
+        'name': 'markup.bold.italic.gfm'
+      '2':
+        'name': 'markup.bold.italic.gfm'
   }
   {
-    'begin': '(?<=^|[^\\w\\d_])___(?!$|_|\\s)'
-    'end': '(?<!^|\\s)___*_(?=$|[^\\w|\\d])'
-    'name': 'markup.bold.italic.gfm'
+    'match': '^__([\\s\\S]+?)__(?!_)|^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)'
+    'captures':
+      '1':
+        'name': 'markup.bold.gfm'
+      '2':
+        'name': 'markup.bold.gfm'
   }
   {
-    'begin': '(?<=^|[^\\w\\d\\*])\\*\\*(?!$|\\*|\\s)'
-    'end': '(?<!^|\\s)\\*\\**\\*(?=$|[^\\w|\\d])'
-    'name': 'markup.bold.gfm'
-  }
-  {
-    'begin': '(?<=^|[^\\w\\d_])__(?!$|_|\\s)'
-    'end': '(?<!^|\\s)__*_(?=$|[^\\w|\\d])'
-    'name': 'markup.bold.gfm'
-  }
-  {
-    'begin': '(?<=^|[^\\w\\d\\*])\\*(?!$|\\*|\\s)'
-    'end': '(?<!^|\\s)\\**\\*(?=$|[^\\w|\\d])'
-    'name': 'markup.italic.gfm'
-  }
-  {
-    'begin': '(?<=^|[^\\w\\d_\\{\\}])_(?!$|_|\\s)'
-    'end': '(?<!^|\\s)_*_(?=$|[^\\w|\\d])'
-    'name': 'markup.italic.gfm'
+    'match': '^\\b_((?:__|[\\s\\S])+?)_\\b|^\\*((?:\\*\\*|[\\s\\S])+?)\\*(?!\\*)'
+    'captures':
+      '1':
+        'name': 'markup.italic.gfm'
+      '2':
+        'name': 'markup.italic.gfm'
   }
   {
     'begin': '(?<=^|[^\\w\\d~])~~(?!$|~|\\s)'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -15,35 +15,6 @@
     'name': 'constant.character.escape.gfm'
   }
   {
-    'match': '^___([\\s\\S]+?)___(?!_)|^\\*\\*\\*([\\s\\S]+?)\\*\\*\\*(?!\\*)'
-    'captures':
-      '1':
-        'name': 'markup.bold.italic.gfm'
-      '2':
-        'name': 'markup.bold.italic.gfm'
-  }
-  {
-    'match': '^__([\\s\\S]+?)__(?!_)|^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)'
-    'captures':
-      '1':
-        'name': 'markup.bold.gfm'
-      '2':
-        'name': 'markup.bold.gfm'
-  }
-  {
-    'match': '^\\b_((?:__|[\\s\\S])+?)_\\b|^\\*((?:\\*\\*|[\\s\\S])+?)\\*(?!\\*)'
-    'captures':
-      '1':
-        'name': 'markup.italic.gfm'
-      '2':
-        'name': 'markup.italic.gfm'
-  }
-  {
-    'begin': '(?<=^|[^\\w\\d~])~~(?!$|~|\\s)'
-    'end': '(?<!^|\\s)~~*~(?=$|[^\\w|\\d])'
-    'name': 'markup.strike.gfm'
-  }
-  {
     'begin': '^(#{6})(\\s*)'
     'end': '$'
     'name': 'markup.heading.heading-6.gfm'
@@ -191,6 +162,35 @@
   {
     'match': '^\\s*[-]{3,}\\s*$'
     'name': 'comment.hr.gfm'
+  }
+  {
+    'match': '^___([\\s\\S]+?)___(?!_)|^\\*\\*\\*([\\s\\S]+?)\\*\\*\\*(?!\\*)'
+    'captures':
+      '1':
+        'name': 'markup.bold.italic.gfm'
+      '2':
+        'name': 'markup.bold.italic.gfm'
+  }
+  {
+    'match': '^__([\\s\\S]+?)__(?!_)|^\\*\\*([\\s\\S]+?)\\*\\*(?!\\*)'
+    'captures':
+      '1':
+        'name': 'markup.bold.gfm'
+      '2':
+        'name': 'markup.bold.gfm'
+  }
+  {
+    'match': '^\\b_((?:__|[\\s\\S])+?)_\\b|^\\*((?:\\*\\*|[\\s\\S])+?)\\*(?!\\*)'
+    'captures':
+      '1':
+        'name': 'markup.italic.gfm'
+      '2':
+        'name': 'markup.italic.gfm'
+  }
+  {
+    'begin': '(?<=^|[^\\w\\d~])~~(?!$|~|\\s)'
+    'end': '(?<!^|\\s)~~*~(?=$|[^\\w|\\d])'
+    'name': 'markup.strike.gfm'
   }
   {
     'begin': '^\\s*[`~]{3,}\\s*coffee-?(script)?\\s*$'


### PR DESCRIPTION
This will fix #84. Since I'm not a regex guru I got some inspiration from the [`marked` package](https://github.com/chjj/marked/blob/2b5802f258c5e23e48366f2377fbb4c807f47658/lib/marked.js#L448-L462).

 - [x] Italic style fix
 - [x] Bold style fix
 - [x] Combined (?)
 - [ ] Handle styles on multiple lines. Example:

   ```md
   *Lorem
   ipsum
   dolor
   sit
   amet*
   ```

## Before
![image](https://cloud.githubusercontent.com/assets/2864371/7159570/d18d988a-e38b-11e4-9ded-1a6f6e40cca3.png)


### After

![image](https://cloud.githubusercontent.com/assets/2864371/7159562/bc3c151a-e38b-11e4-90cc-8c04841c2b28.png)


Waiting for feedback if the direction is good, then I will continue. :smile: 

/cc @izuzak 