### PR TITLE
Gfm critical markup

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -804,4 +804,50 @@
     'end': '--\\s*>'
     'name': 'comment.block.gfm'
   }
+  {
+    'begin': '({\\+\\+)'
+    'end': '(\\+\\+})'
+    'name': 'critic.gfm.addition'
+    'captures':
+      '1':
+        'name': 'critic.gfm.addition.marker'
+  }
+  {
+    'begin': '({--)'
+    'end': '(--})'
+    'name': 'critic.gfm.deletion'
+    'captures':
+      '1':
+        'name': 'critic.gfm.deletion.marker'
+  }
+  {
+    'begin': '({==)'
+    'end': '(==})'
+    'name': 'critic.gfm.highlight'
+    'captures':
+      '1':
+        'name': 'critic.gfm.highlight.marker'
+  }
+  {
+    'begin': '({>>)'
+    'end': '(<<})'
+    'name': 'critic.gfm.comment'
+    'captures':
+      '1':
+        'name': 'critic.gfm.comment.marker'
+  }
+  {
+    'begin': '({~~)'
+    'end': '(~~})'
+    'name': 'critic.gfm.substitution'
+    'captures':
+      '1':
+        'name': 'critic.gfm.substitution.marker'
+    'patterns': [
+      {
+        'match': '~>'
+        'name': 'critic.gfm.substitution.operator'
+      }
+    ]
+  }
 ]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -600,3 +600,36 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("line  ")
     expect(tokens[0]).toEqual value: "line", scopes: ["source.gfm"]
     expect(tokens[1]).toEqual value: "  ", scopes: ["source.gfm", "linebreak.gfm"]
+
+  it "tokenizes criticmarkup", ->
+    [addToken, delToken, hlToken, subToken] = grammar.tokenizeLines """
+    Add{++ some text++}
+    Delete{-- some text--}
+    Highlight {==some text==}{>>with comment<<}
+    Replace {~~this~>by that~~}
+    """
+    # Addition
+    expect(addToken[0]).toEqual value: "Add", scopes: ["source.gfm"]
+    expect(addToken[1]).toEqual value: "{++", scopes: ["source.gfm", "critic.gfm.addition", "critic.gfm.addition.marker"]
+    expect(addToken[2]).toEqual value: " some text", scopes: ["source.gfm", "critic.gfm.addition"]
+    expect(addToken[3]).toEqual value: "++}", scopes: ["source.gfm", "critic.gfm.addition", "critic.gfm.addition.marker"]
+    # Deletion
+    expect(delToken[0]).toEqual value: "Delete", scopes: ["source.gfm"]
+    expect(delToken[1]).toEqual value: "{--", scopes: ["source.gfm", "critic.gfm.deletion", "critic.gfm.deletion.marker"]
+    expect(delToken[2]).toEqual value: " some text", scopes: ["source.gfm", "critic.gfm.deletion"]
+    expect(delToken[3]).toEqual value: "--}", scopes: ["source.gfm", "critic.gfm.deletion", "critic.gfm.deletion.marker"]
+    # Comment and highlight
+    expect(hlToken[0]).toEqual value: "Highlight ", scopes: ["source.gfm"]
+    expect(hlToken[1]).toEqual value: "{==", scopes: ["source.gfm", "critic.gfm.highlight", "critic.gfm.highlight.marker"]
+    expect(hlToken[2]).toEqual value: "some text", scopes: ["source.gfm", "critic.gfm.highlight"]
+    expect(hlToken[3]).toEqual value: "==}", scopes: ["source.gfm", "critic.gfm.highlight", "critic.gfm.highlight.marker"]
+    expect(hlToken[4]).toEqual value: "{>>", scopes: ["source.gfm", "critic.gfm.comment", "critic.gfm.comment.marker"]
+    expect(hlToken[5]).toEqual value: "with comment", scopes: ["source.gfm", "critic.gfm.comment"]
+    expect(hlToken[6]).toEqual value: "<<}", scopes: ["source.gfm", "critic.gfm.comment", "critic.gfm.comment.marker"]
+    # Replace
+    expect(subToken[0]).toEqual value: "Replace ", scopes: ["source.gfm"]
+    expect(subToken[1]).toEqual value: "{~~", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.marker"]
+    expect(subToken[2]).toEqual value: "this", scopes: ["source.gfm", "critic.gfm.substitution"]
+    expect(subToken[3]).toEqual value: "~>", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.operator"]
+    expect(subToken[4]).toEqual value: "by that", scopes: ["source.gfm", "critic.gfm.substitution"]
+    expect(subToken[5]).toEqual value: "~~}", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.marker"]


### PR DESCRIPTION
[CriticMarkup](http://criticmarkup.com/spec.php) is a way of adding tracked changes and editing marks in markdown documents. The syntax is really unobtrusive, and most other markdown editors have it already (see [here](http://criticmarkup.com/tool-list.php)).

I've added the full spec, and here is an example of the output (using colors):

![capture d ecran de 2015-04-15 10 47 42](https://cloud.githubusercontent.com/assets/579329/7161405/e402903a-e35c-11e4-80cd-2f9c254090e7.png)
