### PR TITLE
Add support for Haskell in fenced code blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -606,6 +606,23 @@
     ]
   }
   {
+    'begin': '^\\s*([`~]{3,})\\s*haskell\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.haskell.gfm'
+    'contentName': 'source.haskell'
+    'patterns': [
+      {
+        'include': 'source.haskell'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,}).*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
Haskell code blocks in Markdown files are now properly highlighted.

I copied the same code as here https://github.com/atom/language-gfm/pull/25 and changed it accordingly
