### PR TITLE
Add License field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.72.0",
   "description": "Syntax highlighting and snippets for GitHub Flavored Markdown (GFM).",
   "repository": "https://github.com/atom/language-gfm",
+  "license": "MIT",
   "engines": {
     "atom": "*"
   },


### PR DESCRIPTION
Add license field to `package.json` per https://github.com/atom/atom/pull/6645. :page_facing_up: 