### PR TITLE
Snippets for strike-through and critic markup

### DIFF
--- a/snippets/gfm.cson
+++ b/snippets/gfm.cson
@@ -11,6 +11,21 @@
   'strikethrough text':
     'prefix': 's'
     'body': '~~$1~~$0'
+  'critic addition':
+    'prefix': 'a'
+    'body': '{++$1++}$0'
+  'critic deletion':
+    'prefix': 'd'
+    'body': '{--$1--}$0'
+  'critic substitution':
+    'prefix': 'sub'
+    'body': '{~~${1: }~>${2: }~~}$0'
+  'critic comment':
+    'prefix': 'comment'
+    'body': '{>>$1<<}$0'
+  'critic highlight':
+    'prefix': 'h'
+    'body': '{==$1==}{>>$2<<}$0'
   'link':
     'prefix': 'l'
     'body': '[$1]($2)$0'

--- a/snippets/gfm.cson
+++ b/snippets/gfm.cson
@@ -8,6 +8,9 @@
   'italic text':
     'prefix': 'i'
     'body': '*$1*$0'
+  'strikethrough text':
+    'prefix': 's'
+    'body': '~~$1~~$0'
   'link':
     'prefix': 'l'
     'body': '[$1]($2)$0'


### PR DESCRIPTION
Inspired by https://discuss.atom.io/t/help-with-the-gfm-grammar/16722/3

Since there are snippets for bold and italic text, I think it would make sense to have one for strike-through as well. And maybe for critic markup, too.