### PR TITLE
Match code blocks where whitespace follows the closing ``` tag

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -220,7 +220,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -237,7 +237,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -253,7 +253,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -270,7 +270,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -287,7 +287,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -304,7 +304,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -321,7 +321,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -338,7 +338,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -355,7 +355,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -372,7 +372,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -389,7 +389,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -406,7 +406,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -423,7 +423,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -440,7 +440,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -457,7 +457,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -474,7 +474,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -491,7 +491,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -508,7 +508,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -525,7 +525,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -542,7 +542,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -559,7 +559,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -576,7 +576,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -593,7 +593,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -610,7 +610,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -627,7 +627,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -643,7 +643,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -659,7 +659,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -676,7 +676,7 @@
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1$'
+    'end': '^\\s*\\1\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -225,7 +225,7 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("http://localhost:8080")
     expect(tokens[0]).toEqual value: "http://localhost:8080", scopes: ["source.gfm"]
 
-  it "tokenizes a ``` code block```", ->
+  it "tokenizes a ``` code block", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
     expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
@@ -241,7 +241,23 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("~~~", ruleStack)
     expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
-  it "tokenizes a ``` code block with a language ```", ->
+  it "tokenizes a ``` code block with trailing whitespace", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
+    expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
+    expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
+    {tokens} = grammar.tokenizeLine("```  ", ruleStack)
+    expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+
+  it "tokenizes a ~~~ code block with trailing whitespace", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~mylanguage")
+    expect(tokens[0]).toEqual value: "~~~mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
+    expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
+    {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
+    expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+
+  it "tokenizes a ``` code block with a language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     expect(tokens[0]).toEqual value: "```  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]
 
@@ -254,6 +270,24 @@ describe "GitHub Flavored Markdown grammar", ->
 
     {tokens, ruleStack} = grammar.tokenizeLine("~~~js  ")
     expect(tokens[0]).toEqual value: "~~~js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
+
+  it "tokenizes a ``` code block with a language and trailing whitespace", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
+    {tokens} = grammar.tokenizeLine("```  ", ruleStack)
+    expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.code.shell.gfm", "support.gfm"]
+
+    {tokens, ruleStack} = grammar.tokenizeLine("```js  ")
+    {tokens} = grammar.tokenizeLine("```  ", ruleStack)
+    expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
+
+  it "tokenizes a ~~~ code block with a language and trailing whitespace", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~  bash")
+    {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
+    expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.shell.gfm", "support.gfm"]
+
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~js  ")
+    {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
+    expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
 
   it "tokenizes inline `code` blocks", ->
     {tokens} = grammar.tokenizeLine("`this` is `code`")


### PR DESCRIPTION
I ran into a few issues where code blocks appeared not to close properly because there was space following the e.g.

    ```ruby
    ```(space)

Maybe this is desirable behaviour but in case its not (it was quite annoying and the cause was not immediately apparent) I thought changing the regexp to match trailing whitespace following the final ``` or ~~~ would help.