### PR TITLE
Add Swift support

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -504,6 +504,23 @@
     ]
   }
   {
+    'begin': '^\\s*([`~]{3,})\\s*swift\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.swift.gfm'
+    'contentName': 'source.swift'
+    'patterns': [
+      {
+        'include': 'source.swift'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,})\\s*html\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
Although there is no official support for Swift language highlight, this p-r allows users to see highlighted code if it is surrounded by a `swift` block and a swift language highlight syntax like [this](https://github.com/freebroccolo/atom-language-swift) installed.