### PR TITLE
Case insensitive for language blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -199,7 +199,7 @@
     'name': 'comment.hr.gfm'
   }
   {
-    'begin': '^\\s*[`~]{3,}\\s*coffee-?(script)?\\s*$'
+    'begin': '^\\s*[`~]{3,}\\s*(?i:(coffee-?(script)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -216,7 +216,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(javascript|js)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(javascript|js))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -233,7 +233,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(markdown|mdown|md)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(markdown|mdown|md))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -249,7 +249,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*json\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(json))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -266,7 +266,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*css\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(css))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -283,7 +283,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*less\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(less))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -300,7 +300,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*xml\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(xml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -317,7 +317,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(ruby|rb)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(ruby|rb))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -334,7 +334,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(rust|rs)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(rust|rs))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -351,7 +351,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*java\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(java))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -368,7 +368,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*erlang\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(erlang))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -385,7 +385,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*go(lang)?\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(go(lang)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -402,7 +402,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*cs(harp)?\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(cs(harp)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -419,7 +419,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*php\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(php))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -436,7 +436,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(sh|bash)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(sh|bash))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -453,7 +453,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*py(thon)?\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(py(thon)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -470,7 +470,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*c\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(c))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -487,7 +487,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*c(pp|\\+\\+)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -504,7 +504,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(objc|objective-c)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(objc|objective-c))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -521,7 +521,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*swift\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(swift))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -538,7 +538,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*html\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(html))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -555,7 +555,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*ya?ml\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(ya?ml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -572,7 +572,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*elixir\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(elixir))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -589,7 +589,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(diff|patch|rej)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(diff|patch|rej))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -606,7 +606,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*julia\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(julia))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -623,7 +623,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*r\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(r))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -640,7 +640,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*haskell\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(haskell))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -657,7 +657,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*elm\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(elm))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -674,7 +674,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(apib|apiblueprint)\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(apib|apiblueprint))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -690,7 +690,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*mson\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(mson))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -706,7 +706,7 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\s*sql\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(sql))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -723,7 +723,7 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\s*clojure\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(clojure))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -264,6 +264,9 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```js  ")
     expect(tokens[0]).toEqual value: "```js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
 
+    {tokens, ruleStack} = grammar.tokenizeLine("```JS  ")
+    expect(tokens[0]).toEqual value: "```JS  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
+
   it "tokenizes a ~~~ code block with a language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("~~~  bash")
     expect(tokens[0]).toEqual value: "~~~  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]


### PR DESCRIPTION
This fixes #109. :smile: :tada: 

![image](https://cloud.githubusercontent.com/assets/2864371/9587999/4e78315c-502e-11e5-8f98-1adcfaac0ce1.png)

Not sure if I should add more tests, and if so, how should I continue: just copy-paste the existing code and change the lowercase language names into uppercase?