### PR TITLE
Add Scala syntax highlighting for scala and sbt keywords

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -368,6 +368,23 @@
     ]
   }
   {
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(scala|sbt))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.scala.gfm'
+    'contentName': 'source.scala'
+    'patterns': [
+      {
+        'include': 'source.scala'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,})\\s*(?i:(erlang))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
This mirrors github.com behavior ex:

```scala
def function(arg: Int) = ???
```
```sbt
javaOptions += s"-Djava.library.path=/usr/local/bin"
```

