### PR TITLE
Prevent linting md with fenced code block language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 git:
   depth: 10
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,3 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 git:
   depth: 10
-
-branches:
-  only:
-    - master

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -208,7 +208,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.coffee.gfm'
-    'contentName': 'source.coffee'
+    'contentName': 'embedded.source.coffee'
     'patterns': [
       {
         'include': 'source.coffee'
@@ -225,7 +225,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.js.gfm'
-    'contentName': 'source.js'
+    'contentName': 'embedded.source.js'
     'patterns': [
       {
         'include': 'source.js'
@@ -242,7 +242,8 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.gfm'
-    'patterns': [
+    'contentName': 'embedded.text.md'
+   'patterns': [
       {
         'include': '$self'
       }
@@ -258,7 +259,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.json.gfm'
-    'contentName': 'source.json'
+    'contentName': 'embedded.source.json'
     'patterns': [
       {
         'include': 'source.json'
@@ -275,7 +276,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.css.gfm'
-    'contentName': 'source.css'
+    'contentName': 'embedded.source.css'
     'patterns': [
       {
         'include': 'source.css'
@@ -292,7 +293,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.less.gfm'
-    'contentName': 'source.css.less'
+    'contentName': 'embedded.source.css.less'
     'patterns': [
       {
         'include': 'source.css.less'
@@ -309,7 +310,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.xml.gfm'
-    'contentName': 'text.xml'
+    'contentName': 'embedded.text.xml'
     'patterns': [
       {
         'include': 'text.xml'
@@ -326,7 +327,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.ruby.gfm'
-    'contentName': 'source.ruby'
+    'contentName': 'embedded.source.ruby'
     'patterns': [
       {
         'include': 'source.ruby'
@@ -343,7 +344,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.rust.gfm'
-    'contentName': 'source.rust'
+    'contentName': 'embedded.source.rust'
     'patterns': [
       {
         'include': 'source.rust'
@@ -360,7 +361,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.java.gfm'
-    'contentName': 'source.java'
+    'contentName': 'embedded.source.java'
     'patterns': [
       {
         'include': 'source.java'
@@ -377,7 +378,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.scala.gfm'
-    'contentName': 'source.scala'
+    'contentName': 'embedded.source.scala'
     'patterns': [
       {
         'include': 'source.scala'
@@ -394,7 +395,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.erlang.gfm'
-    'contentName': 'source.erlang'
+    'contentName': 'embedded.source.erlang'
     'patterns': [
       {
         'include': 'source.erlang'
@@ -411,7 +412,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.go.gfm'
-    'contentName': 'source.go'
+    'contentName': 'embedded.source.go'
     'patterns': [
       {
         'include': 'source.go'
@@ -428,7 +429,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.cs.gfm'
-    'contentName': 'source.cs'
+    'contentName': 'embedded.source.cs'
     'patterns': [
       {
         'include': 'source.cs'
@@ -445,7 +446,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.php.gfm'
-    'contentName': 'source.php'
+    'contentName': 'embedded.source.php'
     'patterns': [
       {
         'include': 'source.php'
@@ -462,7 +463,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.shell.gfm'
-    'contentName': 'source.shell'
+    'contentName': 'embedded.source.shell'
     'patterns': [
       {
         'include': 'source.shell'
@@ -479,7 +480,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.python.gfm'
-    'contentName': 'source.python'
+    'contentName': 'embedded.source.python'
     'patterns': [
       {
         'include': 'source.python'
@@ -496,7 +497,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.c.gfm'
-    'contentName': 'source.c'
+    'contentName': 'embedded.source.c'
     'patterns': [
       {
         'include': 'source.c'
@@ -513,7 +514,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.cpp.gfm'
-    'contentName': 'source.cpp'
+    'contentName': 'embedded.source.cpp'
     'patterns': [
       {
         'include': 'source.cpp'
@@ -530,7 +531,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.objc.gfm'
-    'contentName': 'source.objc'
+    'contentName': 'embedded.source.objc'
     'patterns': [
       {
         'include': 'source.objc'
@@ -547,7 +548,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.swift.gfm'
-    'contentName': 'source.swift'
+    'contentName': 'embedded.source.swift'
     'patterns': [
       {
         'include': 'source.swift'
@@ -564,7 +565,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.html.gfm'
-    'contentName': 'source.html.basic'
+    'contentName': 'embedded.text.html.basic'
     'patterns': [
       {
         'include': 'text.html.basic'
@@ -581,7 +582,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.yaml.gfm'
-    'contentName': 'source.yaml'
+    'contentName': 'embedded.source.yaml'
     'patterns': [
       {
         'include': 'source.yaml'
@@ -598,7 +599,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.elixir.gfm'
-    'contentName': 'source.elixir'
+    'contentName': 'embedded.source.elixir'
     'patterns': [
       {
         'include': 'source.elixir'
@@ -615,7 +616,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.diff.gfm'
-    'contentName': 'source.diff'
+    'contentName': 'embedded.source.diff'
     'patterns': [
       {
         'include': 'source.diff'
@@ -632,7 +633,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.julia.gfm'
-    'contentName': 'source.julia'
+    'contentName': 'embedded.source.julia'
     'patterns': [
       {
         'include': 'source.julia'
@@ -649,7 +650,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.r.gfm'
-    'contentName': 'source.r'
+    'contentName': 'embedded.source.r'
     'patterns': [
       {
         'include': 'source.r'
@@ -666,7 +667,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.haskell.gfm'
-    'contentName': 'source.haskell'
+    'contentName': 'embedded.source.haskell'
     'patterns': [
       {
         'include': 'source.haskell'
@@ -683,7 +684,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.elm.gfm'
-    'contentName': 'source.elm'
+    'contentName': 'embedded.source.elm'
     'patterns': [
       {
         'include': 'source.elm'
@@ -700,6 +701,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.gfm'
+    'contentName': 'embedded.text.html.markdown.source.gfm.apib'
     'patterns': [
       {
         'include': 'text.html.markdown.source.gfm.apib'
@@ -716,6 +718,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.gfm'
+    'contentName': 'embedded.text.html.markdown.source.gfm.mson'
     'patterns': [
       {
         'include': 'text.html.markdown.source.gfm.mson'
@@ -732,7 +735,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.sql.gfm'
-    'contentName': 'source.sql'
+    'contentName': 'embedded.source.sql'
     'patterns': [
       {
         'include': 'source.sql'
@@ -749,7 +752,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.clojure.gfm'
-    'contentName': 'source.clojure'
+    'contentName': 'embedded.source.clojure'
     'patterns': [
       {
         'include': 'source.clojure'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -208,7 +208,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.coffee.gfm'
-    'contentName': 'embedded.source.coffee'
+    'contentName': 'source.embedded.coffee'
     'patterns': [
       {
         'include': 'source.coffee'
@@ -225,7 +225,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.js.gfm'
-    'contentName': 'embedded.source.js'
+    'contentName': 'source.embedded.js'
     'patterns': [
       {
         'include': 'source.js'
@@ -259,7 +259,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.json.gfm'
-    'contentName': 'embedded.source.json'
+    'contentName': 'source.embedded.json'
     'patterns': [
       {
         'include': 'source.json'
@@ -276,7 +276,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.css.gfm'
-    'contentName': 'embedded.source.css'
+    'contentName': 'source.embedded.css'
     'patterns': [
       {
         'include': 'source.css'
@@ -293,7 +293,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.less.gfm'
-    'contentName': 'embedded.source.css.less'
+    'contentName': 'source.embedded.css.less'
     'patterns': [
       {
         'include': 'source.css.less'
@@ -327,7 +327,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.ruby.gfm'
-    'contentName': 'embedded.source.ruby'
+    'contentName': 'source.embedded.ruby'
     'patterns': [
       {
         'include': 'source.ruby'
@@ -344,7 +344,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.rust.gfm'
-    'contentName': 'embedded.source.rust'
+    'contentName': 'source.embedded.rust'
     'patterns': [
       {
         'include': 'source.rust'
@@ -361,7 +361,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.java.gfm'
-    'contentName': 'embedded.source.java'
+    'contentName': 'source.embedded.java'
     'patterns': [
       {
         'include': 'source.java'
@@ -378,7 +378,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.scala.gfm'
-    'contentName': 'embedded.source.scala'
+    'contentName': 'source.embedded.scala'
     'patterns': [
       {
         'include': 'source.scala'
@@ -395,7 +395,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.erlang.gfm'
-    'contentName': 'embedded.source.erlang'
+    'contentName': 'source.embedded.erlang'
     'patterns': [
       {
         'include': 'source.erlang'
@@ -412,7 +412,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.go.gfm'
-    'contentName': 'embedded.source.go'
+    'contentName': 'source.embedded.go'
     'patterns': [
       {
         'include': 'source.go'
@@ -429,7 +429,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.cs.gfm'
-    'contentName': 'embedded.source.cs'
+    'contentName': 'source.embedded.cs'
     'patterns': [
       {
         'include': 'source.cs'
@@ -446,7 +446,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.php.gfm'
-    'contentName': 'embedded.source.php'
+    'contentName': 'source.embedded.php'
     'patterns': [
       {
         'include': 'source.php'
@@ -463,7 +463,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.shell.gfm'
-    'contentName': 'embedded.source.shell'
+    'contentName': 'source.embedded.shell'
     'patterns': [
       {
         'include': 'source.shell'
@@ -480,7 +480,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.python.gfm'
-    'contentName': 'embedded.source.python'
+    'contentName': 'source.embedded.python'
     'patterns': [
       {
         'include': 'source.python'
@@ -497,7 +497,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.c.gfm'
-    'contentName': 'embedded.source.c'
+    'contentName': 'source.embedded.c'
     'patterns': [
       {
         'include': 'source.c'
@@ -514,7 +514,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.cpp.gfm'
-    'contentName': 'embedded.source.cpp'
+    'contentName': 'source.embedded.cpp'
     'patterns': [
       {
         'include': 'source.cpp'
@@ -531,7 +531,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.objc.gfm'
-    'contentName': 'embedded.source.objc'
+    'contentName': 'source.embedded.objc'
     'patterns': [
       {
         'include': 'source.objc'
@@ -548,7 +548,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.swift.gfm'
-    'contentName': 'embedded.source.swift'
+    'contentName': 'source.embedded.swift'
     'patterns': [
       {
         'include': 'source.swift'
@@ -582,7 +582,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.yaml.gfm'
-    'contentName': 'embedded.source.yaml'
+    'contentName': 'source.embedded.yaml'
     'patterns': [
       {
         'include': 'source.yaml'
@@ -599,7 +599,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.elixir.gfm'
-    'contentName': 'embedded.source.elixir'
+    'contentName': 'source.embedded.elixir'
     'patterns': [
       {
         'include': 'source.elixir'
@@ -616,7 +616,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.diff.gfm'
-    'contentName': 'embedded.source.diff'
+    'contentName': 'source.embedded.diff'
     'patterns': [
       {
         'include': 'source.diff'
@@ -633,7 +633,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.julia.gfm'
-    'contentName': 'embedded.source.julia'
+    'contentName': 'source.embedded.julia'
     'patterns': [
       {
         'include': 'source.julia'
@@ -650,7 +650,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.r.gfm'
-    'contentName': 'embedded.source.r'
+    'contentName': 'source.embedded.r'
     'patterns': [
       {
         'include': 'source.r'
@@ -667,7 +667,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.haskell.gfm'
-    'contentName': 'embedded.source.haskell'
+    'contentName': 'source.embedded.haskell'
     'patterns': [
       {
         'include': 'source.haskell'
@@ -684,7 +684,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.elm.gfm'
-    'contentName': 'embedded.source.elm'
+    'contentName': 'source.embedded.elm'
     'patterns': [
       {
         'include': 'source.elm'
@@ -735,7 +735,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.sql.gfm'
-    'contentName': 'embedded.source.sql'
+    'contentName': 'source.embedded.sql'
     'patterns': [
       {
         'include': 'source.sql'
@@ -752,7 +752,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.clojure.gfm'
-    'contentName': 'embedded.source.clojure'
+    'contentName': 'source.embedded.clojure'
     'patterns': [
       {
         'include': 'source.clojure'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -242,8 +242,8 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.gfm'
-    'contentName': 'embedded.text.md'
-   'patterns': [
+    'contentName': 'text.embedded.md'
+    'patterns': [
       {
         'include': '$self'
       }
@@ -310,7 +310,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.xml.gfm'
-    'contentName': 'embedded.text.xml'
+    'contentName': 'text.embedded.xml'
     'patterns': [
       {
         'include': 'text.xml'
@@ -565,7 +565,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.html.gfm'
-    'contentName': 'embedded.text.html.basic'
+    'contentName': 'text.embedded.html.basic'
     'patterns': [
       {
         'include': 'text.html.basic'
@@ -701,7 +701,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.gfm'
-    'contentName': 'embedded.text.html.markdown.source.gfm.apib'
+    'contentName': 'text.embedded.html.markdown.source.gfm.apib'
     'patterns': [
       {
         'include': 'text.html.markdown.source.gfm.apib'
@@ -718,7 +718,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.gfm'
-    'contentName': 'embedded.text.html.markdown.source.gfm.mson'
+    'contentName': 'text.embedded.html.markdown.source.gfm.mson'
     'patterns': [
       {
         'include': 'text.html.markdown.source.gfm.mson'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -260,76 +260,76 @@ describe "GitHub Flavored Markdown grammar", ->
   it "tokenizes a ``` code block with a language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     expect(tokens[0]).toEqual value: "```  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```js  ")
     expect(tokens[0]).toEqual value: "```js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```JS  ")
     expect(tokens[0]).toEqual value: "```JS  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```r  ")
     expect(tokens[0]).toEqual value: "```r  ", scopes: ["source.gfm", "markup.code.r.gfm",  "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
   it "tokenizes a Rmarkdown ``` code block", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```{r}")
     expect(tokens[0]).toEqual value: "```{r}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{r,eval=TRUE,cache=FALSE}")
     expect(tokens[0]).toEqual value: "```{r,eval=TRUE,cache=FALSE}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{r eval=TRUE,cache=FALSE}")
     expect(tokens[0]).toEqual value: "```{r eval=TRUE,cache=FALSE}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
   it "tokenizes a Rmarkdown ``` code block with whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```{r   }")
     expect(tokens[0]).toEqual value: "```{r   }", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{R }    ")
     expect(tokens[0]).toEqual value: "```{R }    ", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{r eval = TRUE, cache = FALSE}")
     expect(tokens[0]).toEqual value: "```{r eval = TRUE, cache = FALSE}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
   it "tokenizes a ~~~ code block with a language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("~~~  bash")
     expect(tokens[0]).toEqual value: "~~~  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("~~~js  ")
     expect(tokens[0]).toEqual value: "~~~js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
 
   it "tokenizes a ``` code block with a language and trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
     expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.code.shell.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```js  ")
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
     expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
 
   it "tokenizes a ~~~ code block with a language and trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("~~~  bash")
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
     expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.shell.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("~~~js  ")
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
     expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
-    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
 
   it "tokenizes inline `code` blocks", ->
     {tokens} = grammar.tokenizeLine("`this` is `code`")

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -260,60 +260,76 @@ describe "GitHub Flavored Markdown grammar", ->
   it "tokenizes a ``` code block with a language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     expect(tokens[0]).toEqual value: "```  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```js  ")
     expect(tokens[0]).toEqual value: "```js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```JS  ")
     expect(tokens[0]).toEqual value: "```JS  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```r  ")
     expect(tokens[0]).toEqual value: "```r  ", scopes: ["source.gfm", "markup.code.r.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
   it "tokenizes a Rmarkdown ``` code block", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```{r}")
     expect(tokens[0]).toEqual value: "```{r}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{r,eval=TRUE,cache=FALSE}")
     expect(tokens[0]).toEqual value: "```{r,eval=TRUE,cache=FALSE}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{r eval=TRUE,cache=FALSE}")
     expect(tokens[0]).toEqual value: "```{r eval=TRUE,cache=FALSE}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
   it "tokenizes a Rmarkdown ``` code block with whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```{r   }")
     expect(tokens[0]).toEqual value: "```{r   }", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{R }    ")
     expect(tokens[0]).toEqual value: "```{R }    ", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```{r eval = TRUE, cache = FALSE}")
     expect(tokens[0]).toEqual value: "```{r eval = TRUE, cache = FALSE}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.r"
 
   it "tokenizes a ~~~ code block with a language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("~~~  bash")
     expect(tokens[0]).toEqual value: "~~~  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("~~~js  ")
     expect(tokens[0]).toEqual value: "~~~js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
 
   it "tokenizes a ``` code block with a language and trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
     expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.code.shell.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("```js  ")
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
     expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
 
   it "tokenizes a ~~~ code block with a language and trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("~~~  bash")
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
     expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.shell.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.shell"
 
     {tokens, ruleStack} = grammar.tokenizeLine("~~~js  ")
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
     expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "embedded.source.js"
 
   it "tokenizes inline `code` blocks", ->
     {tokens} = grammar.tokenizeLine("`this` is `code`")


### PR DESCRIPTION
Issue #121 documents that language-gfm incorrectly specifies fenced code blocks with the wrong content names (i.e. `source.js` should be `embedded.source.js`).  This causes problems with linter: when you start typing in a code block with a language that has a linter, the linter will attempt to lint the entire file with that language, generating many spurious errors.  This fixes the issue: code blocks are properly formatted but do not trigger linting.  