### PR TITLE
Add support for highlighting syntax in embedded TypeScript code blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -310,6 +310,23 @@
     ]
   }
   {
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(typescript|ts))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.ts.gfm'
+    'contentName': 'source.embedded.ts'
+    'patterns': [
+      {
+        'include': 'source.ts'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,})\\s*(?i:(markdown|mdown|md))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
The grammar section is nearly identical to the JavaScript one. 

Before:
<img width="870" alt="screen shot 2016-03-07 at 16 49 55" src="https://cloud.githubusercontent.com/assets/5643/13586095/b1937874-e484-11e5-8f20-1cef4825d94b.png">

After:
<img width="860" alt="screen shot 2016-03-07 at 16 47 41" src="https://cloud.githubusercontent.com/assets/5643/13586050/65b9e438-e484-11e5-92e4-1ab7f2a181d2.png">

**Note:** It appears [markdown-preview](https://github.com/atom/markdown-preview) supports the `ts` alias but not `typescript`. Both will work in the editor, though.