### PR TITLE
feat: add 'properties' support

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -581,11 +581,11 @@
     'endCaptures':
       '0':
         'name': 'support.gfm'
-    'name': 'markup.code.java-properties.gfm'
-    'contentName': 'source.embedded.java-properties'
+    'name': 'markup.code.git-config.gfm'
+    'contentName': 'source.embedded.git-config'
     'patterns': [
       {
-        'include': 'source.java-properties'
+        'include': 'source.git-config'
       }
     ]
   }

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -586,6 +586,8 @@
     'patterns': [
       {
         'include': 'source.java-properties'
+      }
+    ]
   }
   {
     'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(shellsession|console))\\s*$'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -548,6 +548,23 @@
     ]
   }
   {
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(properties))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.java-properties.gfm'
+    'contentName': 'source.embedded.java-properties'
+    'patterns': [
+      {
+        'include': 'source.java-properties'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,})\\s*(?i:(py(thon)?))\\s*$'
     'beginCaptures':
       '0':

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -304,6 +304,10 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "```r  ", scopes: ["source.gfm", "markup.code.r.gfm",  "support.gfm"]
     expect(ruleStack[1].contentScopeName).toBe "source.embedded.r"
 
+    {tokens, ruleStack} = grammar.tokenizeLine("```properties  ")
+    expect(tokens[0]).toEqual value: "```properties  ", scopes: ["source.gfm", "markup.code.git-config.gfm",  "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.git-config"
+
   it "tokenizes a Rmarkdown ``` code block", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```{r}")
     expect(tokens[0]).toEqual value: "```{r}", scopes: ["source.gfm", "markup.code.r.gfm", "support.gfm"]
@@ -339,6 +343,10 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "~~~js  ", scopes: ["source.gfm", "markup.code.js.gfm",  "support.gfm"]
     expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
 
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~properties  ")
+    expect(tokens[0]).toEqual value: "~~~properties  ", scopes: ["source.gfm", "markup.code.git-config.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.git-config"
+
   it "tokenizes a ``` code block with a language and trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
@@ -360,6 +368,11 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
     expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.js.gfm", "support.gfm"]
     expect(ruleStack[1].contentScopeName).toBe "source.embedded.js"
+
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~ properties  ")
+    {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
+    expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.code.git-config.gfm", "support.gfm"]
+    expect(ruleStack[1].contentScopeName).toBe "source.embedded.git-config"
 
   it "tokenizes inline `code` blocks", ->
     {tokens} = grammar.tokenizeLine("`this` is `code`")


### PR DESCRIPTION
add support for 'properties' source.

I use `java-properties` but it's possible to use `git-config` for a better support.
What do you think ?

GitHub use `git-config` as support for the `properties` marker:

``` properties
[user]
    name = John Doe
    email = example@examplecom
```
