### PR TITLE
Added pattern matching for inline LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# GitHub flavored Markdown package
-[![OS X Build Status](https://travis-ci.org/atom/language-gfm.svg?branch=master)](https://travis-ci.org/atom/language-gfm) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/rpub8qjyd8lt7wai/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/language-gfm/branch/master) [![Dependency Status](https://david-dm.org/atom/language-gfm.svg)](https://david-dm.org/atom/language-gfm)
+# GitHub flavored Markdown with LaTeX package
+This grammar supports a modified version of GitHub flavored Markdown, with added support of embedded LaTeX code.
+
+[Pandoc](http://pandoc.org/) can compile documents with embedded LaTeX into pure LaTeX documents.
 
 Adds syntax highlighting and snippets to [GitHub flavored Markdown](https://help.github.com/articles/github-flavored-markdown) files in Atom.
 

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1,4 +1,4 @@
-'name': 'GitHub Markdown'
+'name': 'GitHub Markdown with LaTeX'
 'scopeName': 'source.gfm'
 'fileTypes': [
   'markdown'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -979,6 +979,16 @@
     ]
   },
   {
+    'begin': '(?<=^|[^\\w\\d\\$])\\$\\$'
+    'end': '\\$\\$(?=$|[^\\w|\\d])'
+    'name': 'markup.heading.block.latex.gfm'
+  },
+  {
+    'begin': '(?<=^|[^\\w\\d\\$])\\$(?!$|\\$|\\s)'
+    'end': '(?<!^|\\s)\\$(?=$|[^\\w|\\d])'
+    'name': 'markup.heading.inline.latex.gfm'
+  },
+  {
     'begin': '^\\s*([`~]{3,}).*$'
     'beginCaptures':
       '0':

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "language-gfm",
+  "name": "language-gfmlatex",
   "version": "0.88.0",
   "description": "Syntax highlighting and snippets for GitHub Flavored Markdown (GFM).",
-  "repository": "https://github.com/atom/language-gfm",
+  "repository": "https://github.com/n1zzo/language-gfmlatex",
   "license": "MIT",
   "engines": {
     "atom": "*"


### PR DESCRIPTION
Pandoc allows for inline LaTeX inside markdown documents, I've added rules to allow pattern matching of LaTeX code, in both inline and block forms.
I've added the tag heading just to have a quick way to give color to the latex blocks,
however better solutions surely exist.