### PR TITLE
Highlight JSX code blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -310,6 +310,23 @@
     ]
   }
   {
+    'begin': '^\\s*([`~]{3,})\\s*(jsx)\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.js.gfm'
+    'contentName': 'source.js.jsx'
+    'patterns': [
+      {
+        'include': 'source.js.jsx'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,})\\s*(?i:(typescript|ts))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
Some JSX packages might specify JSX as `source.jsx`, but I assumed that language-babel is the most popular, and it uses `source.js.jsx`.
