### PR TITLE
Add scope for code-blocks with unrecognised languages

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -650,7 +650,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc|))\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -979,6 +979,27 @@
     ]
   },
   {
+    'begin': '^\\s*([`~]{3,})(?=\\s*[-\\w]+\\s*$)'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.other.gfm'
+    'patterns': [
+      {
+        'begin': '\\G\\s*([-\\w]+).*$'
+        'beginCaptures':
+          '0':
+            'name': 'support.gfm'
+        'end': '^(?=\\s*[`~]{3,}\\s*$)'
+        'name': 'source.embedded.${1:/downcase}'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,}).*$'
     'beginCaptures':
       '0':

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1021,6 +1021,7 @@
     ]
   }
   {
+    # Attempt to provide syntax highlighting for unknown languages
     'begin': '^\\s*(`{3,}|~{3,})\\s*(?=\\s*[-\\w]+\\s*$)'
     'beginCaptures':
       '0':
@@ -1032,7 +1033,7 @@
     'name': 'markup.code.other.gfm'
     'patterns': [
       {
-        'begin': '\\G\\s*([-\\w]+).*$'
+        'begin': '\\G\\s*([-\\w]+)\\s*$'
         'beginCaptures':
           '0':
             'name': 'support.gfm'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1022,7 +1022,7 @@
   }
   {
     # Attempt to provide syntax highlighting for unknown languages
-    'begin': '^\\s*(`{3,}|~{3,})\\s*(?=\\s*[-\\w]+\\s*$)'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*([-\\w]+)\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -1031,16 +1031,7 @@
       '0':
         'name': 'support.gfm'
     'name': 'markup.code.other.gfm'
-    'patterns': [
-      {
-        'begin': '\\G\\s*([-\\w]+)\\s*$'
-        'beginCaptures':
-          '0':
-            'name': 'support.gfm'
-        'end': '^(?=\\s*[`~]{3,}\\s*$)'
-        'name': 'source.embedded.${1:/downcase}'
-      }
-    ]
+    'contentName': 'source.embedded.${2:/downcase}'
   }
   {
     'begin': '^\\s*(`{3,}|~{3,}).*$'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -226,38 +226,49 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "http://localhost:8080", scopes: ["source.gfm"]
 
   it "tokenizes a ``` code block", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
-    expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("```")
+    expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("```", ruleStack)
     expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
   it "tokenizes a ~~~ code block", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("~~~mylanguage")
-    expect(tokens[0]).toEqual value: "~~~mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~")
+    expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("~~~", ruleStack)
     expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
   it "tokenizes a ``` code block with trailing whitespace", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
-    expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("```")
+    expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
     expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
   it "tokenizes a ~~~ code block with trailing whitespace", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("~~~mylanguage")
-    expect(tokens[0]).toEqual value: "~~~mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~")
+    expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)
     expect(tokens[0]).toEqual value: "~~~  ", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
-  it "tokenizes a ``` code block with a language", ->
+  it "tokenises a ``` code block with an unknown language", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("``` myLanguage")
+    expect(tokens[0]).toEqual value: '```', scopes: ['source.gfm', 'markup.code.other.gfm', 'support.gfm']
+    expect(tokens[1]).toEqual value: ' myLanguage', scopes: ['source.gfm', 'markup.code.other.gfm', 'source.embedded.mylanguage', 'support.gfm']
+
+    {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
+    expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ['source.gfm', 'markup.code.other.gfm', 'source.embedded.mylanguage']
+
+    {tokens} = grammar.tokenizeLine("```", ruleStack)
+    expect(tokens[0]).toEqual value: '```', scopes: ['source.gfm', 'markup.code.other.gfm', 'support.gfm']
+
+  it "tokenizes a ``` code block with a known language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```  bash")
     expect(tokens[0]).toEqual value: "```  bash", scopes: ["source.gfm", "markup.code.shell.gfm",  "support.gfm"]
     expect(ruleStack[1].contentScopeName).toBe "source.embedded.shell"

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -279,8 +279,7 @@ describe "GitHub Flavored Markdown grammar", ->
 
   it "tokenises a ``` code block with an unknown language", ->
     {tokens, ruleStack} = grammar.tokenizeLine("``` myLanguage")
-    expect(tokens[0]).toEqual value: '``` ', scopes: ['source.gfm', 'markup.code.other.gfm', 'support.gfm']
-    expect(tokens[1]).toEqual value: 'myLanguage', scopes: ['source.gfm', 'markup.code.other.gfm', 'source.embedded.mylanguage', 'support.gfm']
+    expect(tokens[0]).toEqual value: '``` myLanguage', scopes: ['source.gfm', 'markup.code.other.gfm', 'support.gfm']
 
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ['source.gfm', 'markup.code.other.gfm', 'source.embedded.mylanguage']


### PR DESCRIPTION
This enables third-party grammars to embed themselves into a Markdown document through injections:

<img src="https://cloud.githubusercontent.com/assets/2346707/19724342/659f9a5c-9bcb-11e6-8a0d-fabf0d6de5d3.png" width="372" alt="My language's symbols are scarier than yours." />

This way, all a grammar needs to add to be highlighted in Markdown snippets is to add this line:

``` coffee
injectionSelector: "source.embedded.NAME"
```
### Notes:
- ~~While doing this, I also stumbled across a bug where any unmarked code-block is incorrectly matched as AsciiDoc. The culprit turned out to be a stray pipe `|` [at the end of the capturing group](https://github.com/atom/language-gfm/blob/master/grammars/gfm.cson#L653), which of course will match anything.~~ **EDIT 2017-04-30:** Moved to a separate PR: #201
- The [extra pattern](https://github.com/Alhadis/language-gfm/blob/dbb42b8ceee2b35b6cf3364bfb7dec535d2b0565/grammars/gfm.cson#L991-L1000) is necessary  for overcoming a technical limitation. See atom/first-mate#82.
