### PR TITLE
Corrected Quote syntax highlighting

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1140,7 +1140,7 @@
     'beginCaptures':
       '1':
         'name': 'support.quote.gfm'
-    'name': 'comment.quote.gfm'
+    'name': 'markup.quote.gfm'
     'patterns': [
       {
         'include': '$self'


### PR DESCRIPTION
Changed quoted text to be read as markup text instead of comment text.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Changed syntax highlighting of quote text to correctly be read as markup text and not comment text.

### Alternate Designs

None considered. Syntax matches that of other languages supported by Atom.

### Benefits

Text will be highlighted correctly as quoted markup.

### Possible Drawbacks

Text highlighting may render differently in custom Atom themes that were styled baed upon the previous incorrect syntax.

### Applicable Issues

Addresses #185.
