### PR TITLE
feat(gfm.cson) highlight embedded graphql

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -963,6 +963,23 @@
     ]
   },
   {
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(graphql))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.graphql.gfm'
+    'contentName': 'source.embedded.graphql'
+    'patterns': [
+      {
+        'include': 'source.graphql'
+      }
+    ]
+  },
+  {
     'begin': '^\\s*([`~]{3,})\\s*(?i:(clojure))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
### Description of the Change

Add support for embedded [graphql](https://github.com/rmosolgo/language-graphql) in fenced code blocks. 

Before: 

![image](https://cloud.githubusercontent.com/assets/2231765/24120609/94c8d9c4-0d8b-11e7-920c-ff602b330baf.png)

After: 

![image](https://cloud.githubusercontent.com/assets/2231765/24120595/8811bcb4-0d8b-11e7-866e-c6b8c117d658.png)

### Alternate Designs

I didn't consider any alternates. I copy-pasted the grammar rule for embedded SQL and replaced `sql` with `graphql`!

### Benefits

Atom users writing GraphQL inside markdown files (eg `README.md`) will have syntax highlighting in their editor which matches the highlighting on GitHub.com. 

### Possible Drawbacks

Maintenance burden! One more embedded language to keep an eye on. 

### Applicable Issues

I didn't see any tests for specific embedded languages, only that, in general, embedded languages are correctly identified and tokenized. Should I add any tests for this change?
