### PR TITLE
Add clj as an alternative indication for Clojure syntax highlight

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -980,7 +980,7 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(clojure))\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(clj|clojure))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'


### PR DESCRIPTION
### Description of the Change

This change will add `clj` as an alternative for `clojure` when adding Clojure-formatted code blocks with triple-backticks, so it works as GitHub does e.g.

```clj
(def sz 20)
(def c (chan sz))
 ```

### Possible Drawbacks

I'm very skeptic of my regexp skills, but `atom --test spec` seems to be ✅  :)
