### PR TITLE
Fix errors with matching embedded code-blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -655,7 +655,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc|))\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -284,11 +284,11 @@
     'name': 'comment.hr.gfm'
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(coffee-?(script)?|cson))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(coffee-?(script)?|cson))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -301,11 +301,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(javascript|js))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(javascript|js))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -318,11 +318,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(typescript|ts))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(typescript|ts))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -335,11 +335,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(markdown|md|mdo?wn|mkdn?|mkdown))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(markdown|md|mdo?wn|mkdn?|mkdown))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -352,11 +352,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(json))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(json))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -369,11 +369,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(css))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(css))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -386,11 +386,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(less))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(less))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -403,11 +403,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(xml))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(xml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -420,11 +420,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(ruby|rb))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(ruby|rb))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -437,11 +437,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(rust|rs))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(rust|rs))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -454,11 +454,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(java))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(java))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -471,11 +471,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(scala|sbt))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(scala|sbt))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -488,11 +488,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(erlang))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(erlang))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -505,11 +505,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(go(lang)?))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(go(lang)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -522,11 +522,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(cs(harp)?))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(cs(harp)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -539,11 +539,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(php))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(php))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -556,11 +556,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(sh|bash|shell))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(sh|bash|shell))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -573,11 +573,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(py(thon)?))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(py(thon)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -590,11 +590,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(pycon))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(pycon))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -607,11 +607,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(c))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(c))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -624,11 +624,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -641,11 +641,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(objc|objective-c))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(objc|objective-c))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -658,11 +658,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -675,11 +675,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(swift))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(swift))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -693,11 +693,11 @@
   }
 
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(dockerfile|docker))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(dockerfile|docker))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -711,11 +711,11 @@
   }
 
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(makefile|make))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(makefile|make))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -729,11 +729,11 @@
   }
 
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(perl))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(perl))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -747,11 +747,11 @@
   }
 
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(perl6))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(perl6))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -765,11 +765,11 @@
   }
 
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(toml))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(toml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -783,11 +783,11 @@
   }
 
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(html))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(html))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -800,11 +800,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(ya?ml))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(ya?ml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -817,11 +817,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(elixir))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(elixir))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -834,11 +834,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(diff|patch|rej))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(diff|patch|rej))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -851,11 +851,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(julia))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(julia))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -868,11 +868,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*([\\{]{0,1})(?i:(r))([^\\}]*)([\\}]{0,1})\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*([\\{]{0,1})(?i:(r))([^\\}]*)([\\}]{0,1})\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -885,11 +885,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(haskell))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(haskell))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -902,11 +902,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(elm))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(elm))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -919,11 +919,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(apib|apiblueprint))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(apib|apiblueprint))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -936,11 +936,11 @@
     ]
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(mson))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(mson))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -953,11 +953,11 @@
     ]
   },
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(sql))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(sql))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -970,11 +970,11 @@
     ]
   },
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(graphql))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(graphql))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -987,11 +987,11 @@
     ]
   },
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(clj|clojure))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(clj|clojure))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -1004,11 +1004,11 @@
     ]
   },
   {
-    'begin': '^\\s*(([`~])\\2{2,}).*$'
+    'begin': '^\\s*(`{3,}|~{3,}).*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*(([`~])\\2{2,})\\s*$'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -281,7 +281,7 @@
     'name': 'comment.hr.gfm'
   }
   {
-    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(coffee-?(script)?))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(coffee-?(script)?|cson))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -281,11 +281,11 @@
     'name': 'comment.hr.gfm'
   }
   {
-    'begin': '^\\s*[`~]{3,}\\s*(?i:(coffee-?(script)?))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(coffee-?(script)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*[`~]{3,}$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -298,11 +298,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(javascript|js))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(javascript|js))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -315,11 +315,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(typescript|ts))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(typescript|ts))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -332,11 +332,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(markdown|mdown|md))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(markdown|mdown|md))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -349,11 +349,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(json))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(json))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -366,11 +366,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(css))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(css))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -383,11 +383,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(less))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(less))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -400,11 +400,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(xml))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(xml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -417,11 +417,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(ruby|rb))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(ruby|rb))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -434,11 +434,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(rust|rs))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(rust|rs))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -451,11 +451,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(java))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(java))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -468,11 +468,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(scala|sbt))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(scala|sbt))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -485,11 +485,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(erlang))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(erlang))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -502,11 +502,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(go(lang)?))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(go(lang)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -519,11 +519,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(cs(harp)?))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(cs(harp)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -536,11 +536,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(php))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(php))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -553,11 +553,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(sh|bash|shell))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(sh|bash|shell))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -570,11 +570,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(py(thon)?))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(py(thon)?))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -587,11 +587,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(pycon))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(pycon))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -604,11 +604,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(c))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(c))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -621,11 +621,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(c(pp|\\+\\+)))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -638,11 +638,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(objc|objective-c))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(objc|objective-c))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -655,11 +655,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(adoc|asciidoc|asciidoctor|asc))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -672,11 +672,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(swift))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(swift))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -690,11 +690,11 @@
   }
 
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(dockerfile|docker))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(dockerfile|docker))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -708,11 +708,11 @@
   }
 
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(makefile|make))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(makefile|make))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -726,11 +726,11 @@
   }
 
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(perl))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(perl))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -744,11 +744,11 @@
   }
 
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(perl6))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(perl6))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -762,11 +762,11 @@
   }
 
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(toml))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(toml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -780,11 +780,11 @@
   }
 
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(html))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(html))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -797,11 +797,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(ya?ml))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(ya?ml))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -814,11 +814,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(elixir))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(elixir))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -831,11 +831,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(diff|patch|rej))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(diff|patch|rej))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -848,11 +848,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(julia))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(julia))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -865,11 +865,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*([\\{]{0,1})(?i:(r))([^\\}]*)([\\}]{0,1})\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*([\\{]{0,1})(?i:(r))([^\\}]*)([\\}]{0,1})\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -882,11 +882,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(haskell))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(haskell))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -899,11 +899,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(elm))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(elm))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -916,11 +916,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(apib|apiblueprint))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(apib|apiblueprint))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -933,11 +933,11 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(mson))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(mson))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -950,11 +950,11 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(sql))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(sql))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -967,11 +967,11 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(graphql))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(graphql))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -984,11 +984,11 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(clj|clojure))\\s*$'
+    'begin': '^\\s*(([`~])\\2{2,})\\s*(?i:(clj|clojure))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'
@@ -1001,11 +1001,11 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,}).*$'
+    'begin': '^\\s*(([`~])\\2{2,}).*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
-    'end': '^\\s*\\1\\s*$'
+    'end': '^\\s*(([`~])\\2{2,})\\s*$'
     'endCaptures':
       '0':
         'name': 'support.gfm'

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -229,16 +229,16 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "http://localhost:8080", scopes: ["source.gfm"]
 
   it "tokenizes a ``` code block", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
-    expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("```")
+    expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("```", ruleStack)
     expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
   it "tokenizes a ~~~ code block", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("~~~mylanguage")
-    expect(tokens[0]).toEqual value: "~~~mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~")
+    expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("~~~", ruleStack)

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -244,6 +244,18 @@ describe "GitHub Flavored Markdown grammar", ->
     {tokens} = grammar.tokenizeLine("~~~", ruleStack)
     expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
+  it "doesn't tokenise ~`~ as a code block", ->
+    {tokens} = grammar.tokenizeLine("~`~mylanguage")
+    expect(tokens[0]).toEqual value: '~', scopes: ['source.gfm']
+    expect(tokens[1]).toEqual value: '`', scopes: ['source.gfm', 'markup.raw.gfm']
+    expect(tokens[2]).toEqual value: '~mylanguage', scopes: ['source.gfm', 'markup.raw.gfm']
+
+  it "tokenises code-blocks with borders of differing lengths", ->
+    [firstLineTokens, secondLineTokens, thirdLineTokens] = grammar.tokenizeLines("~~~\nfoo bar\n~~~~~~~")
+    expect(firstLineTokens[0]).toEqual value: '~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
+    expect(secondLineTokens[0]).toEqual value: 'foo bar', scopes: ['source.gfm', 'markup.raw.gfm']
+    expect(thirdLineTokens[0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
+
   it "tokenizes a ``` code block with trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
     expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -256,6 +256,11 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(secondLineTokens[0]).toEqual value: 'foo bar', scopes: ['source.gfm', 'markup.raw.gfm']
     expect(thirdLineTokens[0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
 
+    [firstLineTokens, secondLineTokens, thirdLineTokens] = grammar.tokenizeLines("~~~~~~~\nfoo bar\n~~~")
+    expect(lines[0][0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
+    expect(lines[1][0]).toEqual value: 'foo bar', scopes: ['source.gfm', 'markup.raw.gfm']
+    expect(lines[2][0]).toEqual value: '~~~', scopes: ['source.gfm', 'markup.raw.gfm']
+
   it "tokenizes a ``` code block with trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```")
     expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -245,10 +245,10 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
   it "doesn't tokenise ~`~ as a code block", ->
-    {tokens} = grammar.tokenizeLine("~`~mylanguage")
+    {tokens} = grammar.tokenizeLine("~`~")
     expect(tokens[0]).toEqual value: '~', scopes: ['source.gfm']
     expect(tokens[1]).toEqual value: '`', scopes: ['source.gfm', 'markup.raw.gfm']
-    expect(tokens[2]).toEqual value: '~mylanguage', scopes: ['source.gfm', 'markup.raw.gfm']
+    expect(tokens[2]).toEqual value: '~', scopes: ['source.gfm', 'markup.raw.gfm']
 
   it "tokenises code-blocks with borders of differing lengths", ->
     [firstLineTokens, secondLineTokens, thirdLineTokens] = grammar.tokenizeLines("~~~\nfoo bar\n~~~~~~~")
@@ -257,16 +257,16 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(thirdLineTokens[0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
 
   it "tokenizes a ``` code block with trailing whitespace", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("```mylanguage")
-    expect(tokens[0]).toEqual value: "```mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("```")
+    expect(tokens[0]).toEqual value: "```", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("```  ", ruleStack)
     expect(tokens[0]).toEqual value: "```  ", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
 
   it "tokenizes a ~~~ code block with trailing whitespace", ->
-    {tokens, ruleStack} = grammar.tokenizeLine("~~~mylanguage")
-    expect(tokens[0]).toEqual value: "~~~mylanguage", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
+    {tokens, ruleStack} = grammar.tokenizeLine("~~~")
+    expect(tokens[0]).toEqual value: "~~~", scopes: ["source.gfm", "markup.raw.gfm", "support.gfm"]
     {tokens, ruleStack} = grammar.tokenizeLine("-> 'hello'", ruleStack)
     expect(tokens[0]).toEqual value: "-> 'hello'", scopes: ["source.gfm", "markup.raw.gfm"]
     {tokens} = grammar.tokenizeLine("~~~  ", ruleStack)

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -257,9 +257,9 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(thirdLineTokens[0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
 
     [firstLineTokens, secondLineTokens, thirdLineTokens] = grammar.tokenizeLines("~~~~~~~\nfoo bar\n~~~")
-    expect(lines[0][0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
-    expect(lines[1][0]).toEqual value: 'foo bar', scopes: ['source.gfm', 'markup.raw.gfm']
-    expect(lines[2][0]).toEqual value: '~~~', scopes: ['source.gfm', 'markup.raw.gfm']
+    expect(firstLineTokens[0]).toEqual value: '~~~~~~~', scopes: ['source.gfm', 'markup.raw.gfm', 'support.gfm']
+    expect(secondLineTokens[0]).toEqual value: 'foo bar', scopes: ['source.gfm', 'markup.raw.gfm']
+    expect(thirdLineTokens[0]).toEqual value: '~~~', scopes: ['source.gfm', 'markup.raw.gfm']
 
   it "tokenizes a ``` code block with trailing whitespace", ->
     {tokens, ruleStack} = grammar.tokenizeLine("```")


### PR DESCRIPTION
### Description of the Change

An unrelated fix included in [`atom/language-gfm#175`](https://github.com/atom/language-gfm/pull/175), but decoupled at @50Wliu's request.

I'll quote the original PR:

> While doing this, I also stumbled across a bug where any unmarked code-block is incorrectly matched as AsciiDoc. The culprit turned out to be a stray pipe `|` [at the end of the capturing group](https://github.com/atom/language-gfm/blob/5dbdc1c/grammars/gfm.cson#L658), which of course will match anything.

**UPDATE:**  
Some other errors were noticed shortly after submission.  They've been fixed and rolled into this PR:

* Mixed runs of ~ and backticks no longer begin a code-block. Fixes [`atom/language-gfm#169`](https://github.com/atom/language-gfm/issues/169).
* Blocks delimited by borders of differing lengths now terminate embedded highlighting correctly.
* Trailing whitespace now handled consistently for closing borders.

I also added CSON as a recognised CoffeeScript keyword, since it's supported on GitHub:

~~~CSON
Snippet:
	prefix: "/"
	body: "/** $1 */"
~~~