### PR TITLE
Update list of Markdown file-extensions

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -5,10 +5,13 @@
   'markdown'
   'md'
   'mdown'
+  'mdwn'
   'mkd'
+  'mkdn'
   'mkdown'
   'rmd'
   'ron'
+  'workbook'
 ]
 'patterns': [
   {
@@ -332,7 +335,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\s*(?i:(markdown|mdown|md))\\s*$'
+    'begin': '^\\s*([`~]{3,})\\s*(?i:(markdown|md|mdo?wn|mkdn?|mkdown))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'


### PR DESCRIPTION
### Description of the Change

This PR syncs the grammar's list of recognised filetypes with [those used on GitHub](https://github.com/github/linguist/blob/eb38c8d/lib/linguist/languages.yml#L2479-L2487):

~~~yml
extensions:
- ".md"
- ".markdown"
- ".mdown"
- ".mdwn"
- ".mkd"
- ".mkdn"
- ".mkdown"
- ".ron"
- ".workbook"
~~~

**References:**
- [`github/linguist#3534`](https://github.com/github/linguist/pull/3534) regarding `.mdwn`
- [`github/linguist#3500`](https://github.com/github/linguist/pull/3500) regarding Xamarin `.workbook` files

### Benefits

Improved file support.

### Possible Drawbacks

None as far as I can tell.

### Applicable Issues

$_
