### PR TITLE
Add support for embedded shell-session blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -573,6 +573,23 @@
     ]
   }
   {
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(shellsession|console))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.shell-session.gfm'
+    'contentName': 'text.embedded.shell-session'
+    'patterns': [
+      {
+        'include': 'text.shell-session'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*([`~]{3,})\\s*(?i:(py(thon)?))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
### Description of the Change

This PR adds support for embedded [shell-session](https://github.com/atom/language-shellscript/blob/master/grammars/shell-session.cson) blocks, which are supported on GitHub using `console` or `shellsession` as language-tags:

~~~markdown
```shellsession
$ echo "string"
"string"
```

```console
# echo "string"
"string"
```
~~~

Output:

```shellsession
$ echo "string"
"string"
```

```console
# echo "string"
"string"
```


### Benefits

Shell-session highlighting is meant for embedded code fragments, such as the ones commonly found in readme files:

~~~console
$ test/run-tests.py expr*const*i32
+ parse/expr/bad-const-i32-just-negative-sign.txt (0.002s)
+ parse/expr/bad-const-i32-overflow.txt (0.003s)
+ parse/expr/bad-const-i32-underflow.txt (0.002s)
+ parse/expr/bad-const-i32-garbage.txt (0.004s)
+ parse/expr/bad-const-i32-trailing.txt (0.002s)
[+5|-0|%100] (0.11s)
~~~

Note that shell commands aren't highlighted inside output lines:

~~~console
$ echo "cd /foo/bar"
cd /foo/bar
~~~

Shell-session blocks also permit `#` as a prompt character:

~~~console
# echo "foo"
foo
~~~

... which the shell-script grammar would interpret as a comment:

~~~bash
# echo "foo"
foo
~~~


### Possible Drawbacks

N/A

### Applicable Issues

N/A
