### PR TITLE
Delete redundant .coffeelintignore file

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,1 +1,0 @@
-spec/fixtures


### PR DESCRIPTION
### Description of the Change

This is a janitorial PR to delete an unused `.coffeelintignore` manifest that's sitting in the package's root directory.

There is no `specs/fixtures` directory, so this file is contributing absolutely nothing.
