### PR TITLE
Add support for embedded JSX

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -318,6 +318,23 @@
     ]
   }
   {
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(jsx))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.jsx.gfm'
+    'contentName': 'source.embedded.jsx'
+    'patterns': [
+      {
+        'include': 'source.js.jsx'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(typescript|ts))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
Didn't test it, but this would be nice to have.

I used `source.js.jsx` as the scope because this is the one used by:
- [react](https://atom.io/packages/react) package for its [JavaScript (JSX) grammar](https://github.com/orktes/atom-react/blob/master/grammars/JavaScript%20(JSX).cson#L2) (721 ★).
- [language-babel](https://atom.io/packages/language-babel) package for its [Babel ES6 JavaScript](https://github.com/gandm/language-babel/blob/master/grammars/Babel%20Language.json#L3) (766 ★).