### PR TITLE
Add bullet point snippet

### DIFF
--- a/snippets/gfm.cson
+++ b/snippets/gfm.cson
@@ -18,6 +18,9 @@
   'link':
     'prefix': 'l'
     'body': '[$1]($2)$0'
+  'bullet point':
+    'prefix': 'p'
+    'body': '- $1'
   'reference':
     'prefix': 'ref'
     'body': '[${1:id}]: ${2:url}${3: "${4:title}"}$0'


### PR DESCRIPTION
### Description of the Change

Add a snippet for bullet points.

### Alternate Designs

Alternatively one could use `*` for the bullet points. However, I used the minus because the todo snippet also uses a minus character.

### Benefits

Adds a useful snippet.

### Possible Drawbacks

None

### Applicable Issues

None