### PR TITLE
support php by copying injections from language-php

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -551,7 +551,7 @@
     'contentName': 'source.embedded.php'
     'patterns': [
       {
-        'include': 'source.php'
+        'include': 'text.html.php'
       }
     ]
   }
@@ -1306,3 +1306,65 @@
     ]
   }
 ]
+'injections':
+  'source.embedded.php - (meta.embedded | meta.tag), L:source.embedded.php meta.tag, L:embedded.source.js.embedded.html':
+    'patterns': [
+      {
+        'begin': '<\\?(?i:php|=)?(?![^?]*\\?>)'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+        'contentName': 'source.php'
+        'end': '(\\?)>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+          '1':
+            'name': 'source.php'
+        'name': 'meta.embedded.block.php'
+        'patterns': [
+          {
+            'include': 'text.html.php#language'
+          }
+        ]
+      }
+      {
+        'begin': '<\\?(?i:php|=)?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.begin.php'
+        'end': '>'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.section.embedded.end.php'
+        'name': 'meta.embedded.line.php'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'source.php'
+              '2':
+                'name': 'punctuation.section.embedded.end.php'
+              '3':
+                'name': 'source.php'
+            'match': '\\G(\\s*)((\\?))(?=>)'
+            'name': 'meta.special.empty-tag.php'
+          }
+          {
+            'begin': '\\G'
+            'contentName': 'source.php'
+            'end': '(\\?)(?=>)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.section.embedded.end.php'
+              '1':
+                'name': 'source.php'
+            'patterns': [
+              {
+                'include': 'text.html.php#language'
+              }
+            ]
+          }
+        ]
+      }
+    ]

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -895,3 +895,14 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(subToken[3]).toEqual value: "~>", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.operator"]
     expect(subToken[4]).toEqual value: "by that", scopes: ["source.gfm", "critic.gfm.substitution"]
     expect(subToken[5]).toEqual value: "~~}", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.marker"]
+
+  it "tokenizes an embedded php block", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("```php")
+    expect(tokens[0]).toEqual value: "```php", scopes: ["source.gfm", "markup.code.php.gfm", "support.gfm"]
+
+    {tokens, ruleStack} = grammar.tokenizeLine("<?php", ruleStack)
+    expect(tokens[0]).toEqual value: "<?php", scopes: ["source.gfm",
+                                                       "markup.code.php.gfm",
+                                                       "source.embedded.php",
+                                                       "meta.embedded.block.php",
+                                                       "punctuation.section.embedded.begin.php"]


### PR DESCRIPTION
| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1423258/31921650-7aed4310-b83e-11e7-9265-944940b590d5.png)  | ![image](https://user-images.githubusercontent.com/1423258/31921657-85eee8a4-b83e-11e7-9884-bf359af29626.png)  |

### Requirements

No new ones.

### Description of the Change

Supports PHP highlighting by copying the `injections` (see [here](https://github.com/atom/language-php/blob/master/grammars/php.cson#L40-L141)). This closely follows a similar solution in the [language-markdown](https://github.com/burodepeper/language-markdown) package.

### Alternate Designs

Just including`text.html.php` in the `patterns` section didn't seem to do it. Personally, not 100% clear why.

Happy to look at better solutions, not personally sure of what they might be.

### Benefits

PHP code gets highlighted.

### Possible Drawbacks

Copying the injections from the `language-php` adds maintenance of keeping them in sync.

### Applicable Issues

None that I saw.
