### PR TITLE
Fix for #218

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1083,7 +1083,7 @@
         'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '(\\[!)(\\[)([^\\]]*)(\\])((\\[)[^\\)]+(\\]))(\\])(((\\()[^\\)]+(\\)))|((\\[)[^\\]]+(\\])))'
+    'match': '(\\[!)(\\[)([^\\]]*)(\\])(\\[)([^\\)]+)(\\])(\\])((\\()([^\\)]+)(\\))|(\\[)([^\\]]+)(\\]))'
     'name': 'link'
     'captures':
       '1':
@@ -1095,23 +1095,23 @@
       '4':
         'name': 'punctuation.definition.end.gfm'
       '5':
-        'name': 'markup.underline.link.gfm'
-      '6':
         'name': 'punctuation.definition.begin.gfm'
+      '6':
+        'name': 'markup.underline.link.gfm'
       '7':
         'name': 'punctuation.definition.end.gfm'
       '8':
         'name': 'punctuation.definition.end.gfm'
       '10':
-        'name': 'markup.underline.link.gfm'
-      '11':
         'name': 'punctuation.definition.begin.gfm'
+      '11':
+        'name': 'markup.underline.link.gfm'
       '12':
         'name': 'punctuation.definition.end.gfm'
       '13':
-        'name': 'markup.underline.link.gfm'
-      '14':
         'name': 'punctuation.definition.begin.gfm'
+      '14':
+        'name': 'markup.underline.link.gfm'
       '15':
         'name': 'punctuation.definition.end.gfm'
   }

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1116,7 +1116,7 @@
         'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '!?(\\[)([^\\]]*)(\\])((\\()[^\\)]+(\\)))'
+    'match': '!?(\\[)([^\\]]*)(\\])(\\()([^\\)]+)(\\))'
     'name': 'link'
     'captures':
       '1':
@@ -1126,14 +1126,14 @@
       '3':
         'name': 'punctuation.definition.end.gfm'
       '4':
-        'name': 'markup.underline.link.gfm'
-      '5':
         'name': 'punctuation.definition.begin.gfm'
+      '5':
+        'name': 'markup.underline.link.gfm'
       '6':
         'name': 'punctuation.definition.end.gfm'
   }
   {
-    'match': '!?(\\[)([^\\]]*)(\\])((\\[)[^\\]]*(\\]))'
+    'match': '!?(\\[)([^\\]]*)(\\])(\\[)([^\\]]*)(\\])'
     'name': 'link'
     'captures':
       '1':
@@ -1143,9 +1143,9 @@
       '3':
         'name': 'punctuation.definition.end.gfm'
       '4':
-        'name': 'markup.underline.link.gfm'
-      '5':
         'name': 'punctuation.definition.begin.gfm'
+      '5':
+        'name': 'markup.underline.link.gfm'
       '6':
         'name': 'punctuation.definition.end.gfm'
   }

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1050,7 +1050,7 @@
     'name': 'markup.raw.gfm'
   }
   {
-    'match': '(\\[!)(\\[)([^\\]]*)(\\])((\\()[^\\)]+(\\)))(\\])(((\\()[^\\)]+(\\)))|((\\[)[^\\]]+(\\])))'
+    'match': '(\\[!)(\\[)([^\\]]*)(\\])(\\()([^\\)]+)(\\))(\\])((\\()([^\\)]+)(\\))|(\\[)([^\\]]+)(\\]))'
     'name': 'link'
     'captures':
       '1':
@@ -1062,23 +1062,23 @@
       '4':
         'name': 'punctuation.definition.end.gfm'
       '5':
-        'name': 'markup.underline.link.gfm'
-      '6':
         'name': 'punctuation.definition.begin.gfm'
+      '6':
+        'name': 'markup.underline.link.gfm'
       '7':
         'name': 'punctuation.definition.end.gfm'
       '8':
         'name': 'punctuation.definition.end.gfm'
       '10':
-        'name': 'markup.underline.link.gfm'
-      '11':
         'name': 'punctuation.definition.begin.gfm'
+      '11':
+        'name': 'markup.underline.link.gfm'
       '12':
         'name': 'punctuation.definition.end.gfm'
       '13':
-        'name': 'markup.underline.link.gfm'
-      '14':
         'name': 'punctuation.definition.begin.gfm'
+      '14':
+        'name': 'markup.underline.link.gfm'
       '15':
         'name': 'punctuation.definition.end.gfm'
   }

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -386,9 +386,9 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[5]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes reference [links][links]", ->
     {tokens} = grammar.tokenizeLine("please click [this link][website]")
@@ -396,9 +396,9 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[5]).toEqual value: "website", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes id-less reference [links][]", ->
     {tokens} = grammar.tokenizeLine("please click [this link][]")
@@ -406,8 +406,8 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "this link", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
-    expect(tokens[5]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
+    expect(tokens[5]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes [link]: footers", ->
     {tokens} = grammar.tokenizeLine("[aLink]: http://website")
@@ -433,13 +433,13 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
     expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[8]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[8]).toEqual value: "(", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[10]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[10]).toEqual value: ")", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes [![links](links)][links]", ->
     {tokens} = grammar.tokenizeLine("[![title](image)][link]")
@@ -447,13 +447,13 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[4]).toEqual value: "(", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[6]).toEqual value: ")", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
     expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[8]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[8]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[10]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[10]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes [![links][links]](links)", ->
     {tokens} = grammar.tokenizeLine("[![title][image]](link)")
@@ -461,13 +461,13 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
     expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[8]).toEqual value: "(", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[8]).toEqual value: "(", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[10]).toEqual value: ")", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[10]).toEqual value: ")", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes [![links][links]][links]", ->
     {tokens} = grammar.tokenizeLine("[![title][image]][link]")
@@ -475,13 +475,13 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(tokens[1]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[2]).toEqual value: "title", scopes: ["source.gfm", "link", "entity.gfm"]
     expect(tokens[3]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[4]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[5]).toEqual value: "image", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[6]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
     expect(tokens[7]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
-    expect(tokens[8]).toEqual value: "[", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.begin.gfm"]
+    expect(tokens[8]).toEqual value: "[", scopes: ["source.gfm", "link", "punctuation.definition.begin.gfm"]
     expect(tokens[9]).toEqual value: "link", scopes: ["source.gfm", "link", "markup.underline.link.gfm"]
-    expect(tokens[10]).toEqual value: "]", scopes: ["source.gfm", "link", "markup.underline.link.gfm", "punctuation.definition.end.gfm"]
+    expect(tokens[10]).toEqual value: "]", scopes: ["source.gfm", "link", "punctuation.definition.end.gfm"]
 
   it "tokenizes mentions", ->
     {tokens} = grammar.tokenizeLine("sentence with no space before@name ")


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

As per #218, this PR fixes the scoping of links in patterns such as `![text](link)`

The changes are relatively minor. Each relevant regex used to have a capture group around the parentheses and the contents, and this group was scoped to `markup.underline.link`. My PR removes this capture group (as it was not used otherwise) and introduces a new one strictly around the contents of the parentheses.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I could have left the outer capture group in there and introduced an entirely new one, but that would have meant reworking a lot of group numbers. As my solution effectively "moved" the group, only a couple of group numbers were affected.

### Benefits

<!-- What benefits will be realized by the code change? -->

Links are properly scoped to just the part that is actually a link. Note that I don't understand some how some of the link syntax works, I've just been going off what was already labelled as a link.

Fixed constructions: 

```gfm
[![text1](link1)](link2)
[![text1](link1)][link2]

[![text1][link1]][link2]
[![text1][link1]](link2)

![text1](link1)
[text1](link1)

![text1][link1]
[text1][link1]

[text1]:<link --- or not link?
[text1]:<link <!-- it breaks comments :( -->
[text1]:<link1>

[text1]:link1

[text1](link1)
```

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None I am aware of. As stated, the removed capture groups were not used anyway. Someone needing them in the future would need to put some effort in to correct group numbers, but I don't expect this to happen.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#218 

### Other notes
Seen in the benefits section, there are some patterns (already present; not introduced or addressed by this PR) that highlight counterintuitivly. Eg. does `[text]:<link` need a closing `>`?

I also dont know much about testing, so any help with that (if necessary for this change) would be appreciated.