### PR TITLE
Support Embedded LaTeX & Mathematica

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1021,6 +1021,40 @@
     ]
   }
   {
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(latex))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.latex.gfm'
+    'contentName': 'source.embedded.latex'
+    'patterns': [
+      {
+        'include': 'text.tex.latex'
+      }
+    ]
+  }
+  {
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(mathematica))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.mathematica.gfm'
+    'contentName': 'source.embedded.mathematica'
+    'patterns': [
+      {
+        'include': 'source.mathematica'
+      }
+    ]
+  }
+  {
     # Attempt to provide syntax highlighting for unknown languages
     'begin': '^\\s*(`{3,}|~{3,})\\s*([-\\w]+)\\s*$'
     'beginCaptures':

--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1055,6 +1055,23 @@
     ]
   }
   {
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(matlab))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.matlab.gfm'
+    'contentName': 'source.embedded.matlab'
+    'patterns': [
+      {
+        'include': 'source.matlab'
+      }
+    ]
+  }
+  {
     # Attempt to provide syntax highlighting for unknown languages
     'begin': '^\\s*(`{3,}|~{3,})\\s*([-\\w]+)\\s*$'
     'beginCaptures':


### PR DESCRIPTION
Adds specific code highlighting rules for LaTeX and mathematica

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

I copy and pasted the `clojure` rule and replaced the clojure specific stuff with LaTeX and mathematica equivalents.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None. No tests were added because even now not all supported languages have tests.

### Benefits

<!-- What benefits will be realized by the code change? -->
Highlighting of these languages occurs, rather than being effectively ignored (not even shown as `markup.raw`).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

It risks unclosed rules gobbling the ending backticks. However, this issue is the same for any other language that's already getting it's own highlighting, and a solution is not available yet.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#213 
