### PR TITLE
allow `jl` to be used for julia code blocks

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -868,7 +868,7 @@
     ]
   }
   {
-    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(julia))\\s*$'
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(julia|jl))\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'


### PR DESCRIPTION
on github `jl` is a valid code block identifier for the Julia language. This PR
updates language-gfm to match.