### PR TITLE
Fix CriticMarkup scope names

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -1262,18 +1262,18 @@
   {
     'begin': '{\\+\\+'
     'end': '\\+\\+}'
-    'name': 'critic.gfm.addition'
+    'name': 'markup.inserted.critic.gfm.addition'
     'captures':
       '0':
-        'name': 'critic.gfm.addition.marker'
+        'name': 'punctuation.definition.inserted.critic.gfm.addition.marker'
   }
   {
     'begin': '{--'
     'end': '--}'
-    'name': 'critic.gfm.deletion'
+    'name': 'markup.deleted.critic.gfm.deletion'
     'captures':
       '0':
-        'name': 'critic.gfm.deletion.marker'
+        'name': 'punctuation.definition.deleted.critic.gfm.deletion.marker'
   }
   {
     'begin': '{=='
@@ -1294,14 +1294,14 @@
   {
     'begin': '{~~'
     'end': '~~}'
-    'name': 'critic.gfm.substitution'
+    'name': 'markup.changed.critic.gfm.substitution'
     'captures':
       '0':
-        'name': 'critic.gfm.substitution.marker'
+        'name': 'punctuation.definition.changed.critic.gfm.substitution.marker'
     'patterns': [
       {
         'match': '~>'
-        'name': 'critic.gfm.substitution.operator'
+        'name': 'punctuation.definition.changed.critic.gfm.substitution.operator'
       }
     ]
   }

--- a/spec/gfm-spec.coffee
+++ b/spec/gfm-spec.coffee
@@ -872,14 +872,14 @@ describe "GitHub Flavored Markdown grammar", ->
     """
     # Addition
     expect(addToken[0]).toEqual value: "Add", scopes: ["source.gfm"]
-    expect(addToken[1]).toEqual value: "{++", scopes: ["source.gfm", "critic.gfm.addition", "critic.gfm.addition.marker"]
-    expect(addToken[2]).toEqual value: " some text", scopes: ["source.gfm", "critic.gfm.addition"]
-    expect(addToken[3]).toEqual value: "++}", scopes: ["source.gfm", "critic.gfm.addition", "critic.gfm.addition.marker"]
+    expect(addToken[1]).toEqual value: "{++", scopes: ["source.gfm", "markup.inserted.critic.gfm.addition", "punctuation.definition.inserted.critic.gfm.addition.marker"]
+    expect(addToken[2]).toEqual value: " some text", scopes: ["source.gfm", "markup.inserted.critic.gfm.addition"]
+    expect(addToken[3]).toEqual value: "++}", scopes: ["source.gfm", "markup.inserted.critic.gfm.addition", "punctuation.definition.inserted.critic.gfm.addition.marker"]
     # Deletion
     expect(delToken[0]).toEqual value: "Delete", scopes: ["source.gfm"]
-    expect(delToken[1]).toEqual value: "{--", scopes: ["source.gfm", "critic.gfm.deletion", "critic.gfm.deletion.marker"]
-    expect(delToken[2]).toEqual value: " some text", scopes: ["source.gfm", "critic.gfm.deletion"]
-    expect(delToken[3]).toEqual value: "--}", scopes: ["source.gfm", "critic.gfm.deletion", "critic.gfm.deletion.marker"]
+    expect(delToken[1]).toEqual value: "{--", scopes: ["source.gfm", "markup.deleted.critic.gfm.deletion", "punctuation.definition.deleted.critic.gfm.deletion.marker"]
+    expect(delToken[2]).toEqual value: " some text", scopes: ["source.gfm", "markup.deleted.critic.gfm.deletion"]
+    expect(delToken[3]).toEqual value: "--}", scopes: ["source.gfm", "markup.deleted.critic.gfm.deletion", "punctuation.definition.deleted.critic.gfm.deletion.marker"]
     # Comment and highlight
     expect(hlToken[0]).toEqual value: "Highlight ", scopes: ["source.gfm"]
     expect(hlToken[1]).toEqual value: "{==", scopes: ["source.gfm", "critic.gfm.highlight", "critic.gfm.highlight.marker"]
@@ -890,8 +890,8 @@ describe "GitHub Flavored Markdown grammar", ->
     expect(hlToken[6]).toEqual value: "<<}", scopes: ["source.gfm", "critic.gfm.comment", "critic.gfm.comment.marker"]
     # Replace
     expect(subToken[0]).toEqual value: "Replace ", scopes: ["source.gfm"]
-    expect(subToken[1]).toEqual value: "{~~", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.marker"]
-    expect(subToken[2]).toEqual value: "this", scopes: ["source.gfm", "critic.gfm.substitution"]
-    expect(subToken[3]).toEqual value: "~>", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.operator"]
-    expect(subToken[4]).toEqual value: "by that", scopes: ["source.gfm", "critic.gfm.substitution"]
-    expect(subToken[5]).toEqual value: "~~}", scopes: ["source.gfm", "critic.gfm.substitution", "critic.gfm.substitution.marker"]
+    expect(subToken[1]).toEqual value: "{~~", scopes: ["source.gfm", "markup.changed.critic.gfm.substitution", "punctuation.definition.changed.critic.gfm.substitution.marker"]
+    expect(subToken[2]).toEqual value: "this", scopes: ["source.gfm", "markup.changed.critic.gfm.substitution"]
+    expect(subToken[3]).toEqual value: "~>", scopes: ["source.gfm", "markup.changed.critic.gfm.substitution", "punctuation.definition.changed.critic.gfm.substitution.operator"]
+    expect(subToken[4]).toEqual value: "by that", scopes: ["source.gfm", "markup.changed.critic.gfm.substitution"]
+    expect(subToken[5]).toEqual value: "~~}", scopes: ["source.gfm", "markup.changed.critic.gfm.substitution", "punctuation.definition.changed.critic.gfm.substitution.marker"]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR changes the scope names for CriticMarkup insertions, deletions and substitutions to be more in line with existing naming conventions, in particular [language-diff](https://github.com/miketheman/language-diff/blob/master/grammars/diff.cson#L74-L98), the official [GitHub syntax theme](https://github.com/primer/github-syntax-theme-generator/blob/master/lib/themes/light.json#L295-L316), and the [TextMate naming conventions](https://manual.macromates.com/en/language_grammars#naming_conventions).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

It might have been cleaner to change the scope names to something like `markup.{inserted,deleted,changed}.gfm`, but this would likely break existing themes relying on the current scope names. To avoid this, the current scope names have been retained as a suffix.

### Benefits

<!-- What benefits will be realized by the code change? -->

The main benefit is better compatibility with existing syntax themes:

![Before - GitHub Light syntax theme](https://user-images.githubusercontent.com/24291/39078433-8f71542e-454d-11e8-8989-ecc61ef405aa.png)

![After - GitHub Light syntax theme](https://user-images.githubusercontent.com/24291/39078352-87c3d27a-454c-11e8-8641-5656ec4cfcdc.png)

![Before - One Dark syntax theme](https://user-images.githubusercontent.com/24291/39078445-bb8eb74a-454d-11e8-84af-ad1040474db5.png)

![After - One Dark syntax theme](https://user-images.githubusercontent.com/24291/39078371-bac169da-454c-11e8-8e56-6b6111467686.png)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

As noted earlier, changing the scope names runs the risk of breaking existing themes, but I've tried to avoid this from happening by not removing any of the groups currently in the scope names.

![Before - Pen Paper Coffee syntax theme](https://user-images.githubusercontent.com/24291/39078463-eb333d72-454d-11e8-865f-c5c3dc00fcd0.png)

![After - Pen Paper Coffee syntax theme](https://user-images.githubusercontent.com/24291/39078380-ebf0203c-454c-11e8-88a3-c7df7b8afcba.png)

### Applicable Issues

<!-- Enter any applicable Issues here -->

github/linguist#4108
