### PR TITLE
Update gfm.cson for Kotlin highlighting

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -471,6 +471,23 @@
     ]
   }
   {
+    'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(kotlin))\\s*$'
+    'beginCaptures':
+      '0':
+        'name': 'support.gfm'
+    'end': '^\\s*\\1((?<=`)`+|(?<=~)~+)?\\s*$'
+    'endCaptures':
+      '0':
+        'name': 'support.gfm'
+    'name': 'markup.code.kotlin.gfm'
+    'contentName': 'source.embedded.kotlin'
+    'patterns': [
+      {
+        'include': 'source.kotlin'
+      }
+    ]
+  }
+  {
     'begin': '^\\s*(`{3,}|~{3,})\\s*(?i:(scala|sbt))\\s*$'
     'beginCaptures':
       '0':


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds [Kotlin](http://kotlinlang.org/) syntax highlighting for code blocks.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
n/a

### Benefits

<!-- What benefits will be realized by the code change? -->

The Kotlin language can now have syntax highlighting when editing markdown code blocks. This increases readability when editing markdown.

Github supports Kotlin highlighting, see the below.

```kotlin
    // Firebase tokens cannot be obtained on the main thread.
    Thread(Runnable {
      try {
        val token = FirebaseInstanceId.getInstance().getToken("<YOUR_SENDER_ID>", "FCM")
        Appboy.getInstance(applicationContext).registerAppboyPushMessages(token)
      } catch (e: Exception) {
        Log.e(TAG, "Exception while registering Firebase token with Braze.", e)
      }
    }).start()
```

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I do not foresee any drawbacks to Kotlin language highlighting.

### Applicable Issues

<!-- Enter any applicable Issues here -->
https://github.com/atom/language-gfm/issues/166
